### PR TITLE
Improve localization docs and correct an unnecessarily complex pattern

### DIFF
--- a/Components/Rules.lua
+++ b/Components/Rules.lua
@@ -591,7 +591,8 @@ function Rules:TestItemAttribute(
 
 			-- Do we have a match?
 			if matchType == BS_RULE_MATCH_TYPE.EQUALS then
-				if itemAttribute == argument or (matchViaLocalization and itemAttribute == L[argument]) then
+				-- Need to use L_nil here to avoid inaccurate localization miss messages when debug is on.
+				if itemAttribute == argument or (matchViaLocalization and itemAttribute == L_nil[argument]) then
 					return true
 				end
 

--- a/Locale/Readme.md
+++ b/Locale/Readme.md
@@ -11,18 +11,42 @@
    ```xml
    <Include file="{newLocale}.lua" />
    ```
-5. Translate everything on the **RIGHT** sides of the equals signs (*do not* edit anything on the left), taking into account the guidance below. You can test changes by reloading the UI.
+5. Translate the strings on the **RIGHT** sides of the equals signs (*do not* edit anything on the left), taking into account the guidance below. You can test changes by reloading the UI.
 
 ## Guidance
 
-* Any time you see `%s`, `%d`, or any other Lua pattern, it must continue to exist *unaltered* at the appropriate location in the translated version of the string.
+### 🟢 Matching in-game text
+It's critical that some localized strings aren't just translated, but that they ***exactly*** match what the game provides:
+* Everything in the `### Game Stuff ###` section at the top of the locale file.
+* `NameIdentifier_.*`
+* `TooltipIdentifier_.*`
+* `TooltipParse_.*`
 
-* When `_G.<WORD>` is on the right side, this is referencing a built-in global string that *probably* should not require manual translation.
+If these are inaccurate, some rules and other functionality won't work properly.
 
-* Anything surrounded by `!!DoubleExclamationMarks!!` is a placeholder reference to a localization string that will be replaced when the localization is loaded. It must *not* be changed.
+### 🟥 `%s`, `%d`
+Any time you see `%s`, `%d`, or any other Lua formatting placeholder or pattern class, it must continue to exist ***unaltered*** at the appropriate location in the translated version of the string.
 
-* Some strings are concatenated, for example:
-  ```lua
-  "Show the hearthstone button." .. BS_NEWLINE .. LIGHTYELLOW_FONT_COLOR_CODE .. "Applies to Bags only" .. FONT_COLOR_CODE_CLOSE,
-  ```
-  Only the string parts (inside "quotation marks") should be translated. The `LOUD_SNAKE_CASE` words are variables that must *not* be changed.
+### 🟥 `!!DoubleExclamationMarks!!`
+
+Anything surrounded by `!!DoubleExclamationMarks!!` is a placeholder reference to a localization string that will be replaced when the localization is loaded. It must ***not*** be changed.
+
+### 🟥 Variables and concatenation
+
+Some strings are concatenated, for example:
+```lua
+"Show the hearthstone button." .. BS_NEWLINE .. LIGHTYELLOW_FONT_COLOR_CODE .. "Applies to Bags only" .. FONT_COLOR_CODE_CLOSE,
+```
+Only the string parts (inside "quotation marks") should be translated. The `LOUD_SNAKE_CASE` words are variables that must ***not*** be changed
+
+### 🔶 `_G.<ANYTHING>`
+
+When `_G.<ANYTHING>` is on the right side, this is referencing a built-in global string that *probably* should not require manual translation.
+
+### ℹ️ Ignore comments
+
+There's no need to translate the comments at the end of some lines (the part outside the final `"` that is demarcated by `--`).
+
+```lua
+["String"] = "Translation",  -- This is a comment
+```

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -457,8 +457,8 @@ BsLocalization:AddLocale("enUS", {
 ["TooltipIdentifier_Food"] = [[Must remain seated while eating]],
 ["TooltipIdentifier_Mount"] = [[Use: Summons and dismisses a rideable]],
 ["TooltipIdentifier_MountAQ40"] = [[Use: Emits a high frequency sound]],
-["TooltipIdentifier_PotionHealth"] = [[/Restores [%d.]+ to [%d.]+ health\./]],  -- Wrap in slashes to activate pattern matching.
-["TooltipIdentifier_PotionMana"] = [[/Restores [%d.]+ to [%d.]+ mana\./]],  -- Wrap in slashes to activate pattern matching.
+["TooltipIdentifier_PotionHealth"] = [[/Restores %d+ to %d+ health\./]],  -- Wrap in slashes to activate pattern matching.
+["TooltipIdentifier_PotionMana"] = [[/Restores %d+ to %d+ mana\./]],  -- Wrap in slashes to activate pattern matching.
 ["TooltipIdentifier_QuestItem"] = [[Quest Item]],
 
 -- Tooltip parsing -- extracting data from tooltips.


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail -->
* Improve guidance in the "How to localize" document
* Avoid unnecessary localization debug messages from rule functions
* Fix the bafflingly strange way I wrote the mana and health potion pattern

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please include a link (i.e. #issueNumber). -->
Mostly #77. The mana/health pattern thing is just something I noticed while looking at localization stuff.

## Testing
<!--- Please describe in detail how you tested your changes. -->
Verified that health and mana potions still categorize correctly with the new pattern.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Remove all that DON’T apply. -->
- Bug fix <!--- Non-breaking change that resolves an issue -->
- Localization
- Other (please describe):
	- Documentation
