### PR TITLE
Make the Organize button smarter

### DIFF
--- a/Components/Categories.lua
+++ b/Components/Categories.lua
@@ -471,7 +471,7 @@ end
 ---@param item table An item from the Bagshui inventory cache (should be based on `BS_ITEM_SKELETON`).
 ---@param character table? Character information table (uses `Bagshui.currentCharacterInfo` if not provided).
 ---@param sortedSequenceNumbers number[] An array of numbers that correspond to indexes of the `categoriesToGroups` table. This is what dictates priority of category evaluation.
----@param categoriesToGroups table Table of `{ <sequence number> = { categoryId1 = groupId1, categoryId2, = groupId2 } }`. (The `categoryIdsGroupedBySequence` table produced by `Inventory:UpdateLayoutLookupTables()`).
+---@param categoriesToGroups table Table of `{ <sequence number> = { categoryId1 = groupId1, categoryId2 = groupId2 } }`. (The `categoryIdsGroupedBySequence` table produced by `Inventory:UpdateLayoutLookupTables()`).
 ---@param defaultCategoryId string|number? If no matching category is found, assign the item to this category. (When not specified, use `Categories.defaultCategoryId`).
 function Categories:Categorize(item, character, sortedSequenceNumbers, categoriesToGroups, defaultCategoryId)
 	if not item then

--- a/Components/Inventory.Cache.lua
+++ b/Components/Inventory.Cache.lua
@@ -64,6 +64,10 @@ function Inventory:UpdateCache()
 	-- Used to determine whether change highlighting should be enabled.
 	self.hasChanges = false
 
+	-- Whether any item in the cache has the `_bagshuiPreventEmptySlotStack` property set to `true`
+	-- Used by `ManageDryRun()` as a factor to determine whether `enableResortIcon` should be true.
+	self.hasSlotsWithStackingPrevented = false
+
 	-- Bag (outer loop) variables.
 	local bagName, bagNumSlots, bagTexture, bagType, bagSlotLink, bagItemCode, bagInfo
 
@@ -535,6 +539,11 @@ function Inventory:UpdateCache()
 			-- Update tracking of whether there are highlight-able items.
 			if item.bagshuiStockState ~= BS_ITEM_STOCK_STATE.NO_CHANGE then
 				self.hasChanges = true
+			end
+
+			-- Update tracking of empty slots peeled off the stack.
+			if item._bagshuiPreventEmptySlotStack then
+				self.hasSlotsWithStackingPrevented = true
 			end
 		end
 	end

--- a/Components/Inventory.Layout.lua
+++ b/Components/Inventory.Layout.lua
@@ -5,6 +5,12 @@
 Bagshui:AddComponent(function()
 local Inventory = Bagshui.prototypes.Inventory
 
+-- When deciding whether there are differences between a dry run and current state,
+-- some tables need to be compared deeper than the default of 1 level. Set those here.
+local LAYOUT_LOOKUP_TABLE_COMPARE_DEPTH = {
+	categoryIdsGroupedBySequence = 2,
+	groupItems = 2,
+}
 
 -- Reusable variable for use in `Inventory:Update()`.
 local update_cascadeInventory
@@ -53,7 +59,10 @@ function Inventory:Update(cascade)
 
 	-- Perform all updates in the necessary order.
 	self:ValidateLayout()
+	self:ManageDryRun()  -- First call decides whether we're in dry run mode.
+	self:UpdateLayoutLookupTables()
 	self:CategorizeAndSort()
+	self:ManageDryRun()  -- Second call re-points lookup tables if needed and sets `enableResortIcon`.
 	self:FindSpecialItems()
 	self:UpdateWindow()
 	self:UpdateBagBar()
@@ -126,6 +135,83 @@ end
 
 
 
+--- Control whether the current layout update is a dry run or not.
+--- **Should not be called directly!** Use `Inventory:Update()` to coordinate the process.
+--- 
+--- Doing a dry run means storing information in the `proposedLayoutState` tables
+--- instead of `currentLayoutState`. The proposed state can then be compared
+--- to current to decide whether resorting is needed.
+--- 
+--- This must be called twice during the `Update()` process - once at the beginning
+--- and then again before calling `UpdateWindow()`.
+function Inventory:ManageDryRun()
+	if not self.dryRunNeedsReset then
+		-- Determine whether this is real or if we're just simulating to decide whether there are changes.
+		self.dryRun = false
+		-- Ensure items don't shift around when the window is open under normal usage.
+		-- self.forceResort can be used to override (usually when the user clicks the Resort button).
+		if
+			(
+				not self.resortNeeded
+				or self:Visible()
+			)
+			and not self.forceResort
+		then
+			self.dryRun = true
+			self:PrintDebug("++++DRY RUN ON++++")
+		else
+			self:PrintDebug("----dry run off----")
+		end
+
+		-- Reset force resort flag.
+		self.forceResort = false
+
+		-- Point layout state tracking keys to the correct tables.
+		for key, _ in pairs(self.currentLayoutState) do
+			self[key] = self[self.dryRun and "proposedLayoutState" or "currentLayoutState"][key]
+		end
+
+		self.dryRunNeedsReset = true
+
+	else
+		-- Resetting tables to current if needed.
+		-- Decide whether the resort icon needs to be enabled.
+		self.enableResortIcon = false
+		-- Special stuff for dry run mode:
+		-- - Manage the resort icon.
+		-- - Re-point layout state tables.
+		if
+			self.dryRun
+			-- Safety check to ensure pointers are always reset.
+			or self.groups ~= self.currentLayoutState.groups
+		then
+			for key, _ in pairs(self.currentLayoutState) do
+				if
+					self.dryRun
+					and not self.enableResortIcon  -- No need to keep checking once we've hit true.
+					and not BsUtil.ObjectsEqual(
+						self.proposedLayoutState[key],
+						self.currentLayoutState[key],
+						nil, nil,
+						LAYOUT_LOOKUP_TABLE_COMPARE_DEPTH[key] or 1
+					)
+				then
+					self.enableResortIcon = true
+				end
+
+				-- Always swap back to the "current" layout state for UpdateWindow() instead
+				-- of the dry run one so that nothing moves around undesirably.
+				self[key] = self.currentLayoutState[key]
+			end
+		end
+
+		self.dryRunNeedsReset = false
+	end
+	
+end
+
+
+
 --- Assign inventory items to Bagshui categories and sort into the correct order for display.  
 --- **Should not be called directly!** Use `Inventory:Update()` to coordinate the process.
 ---
@@ -136,53 +222,8 @@ end
 function Inventory:CategorizeAndSort()
 	--self:PrintDebug("CategorizeAndSort()")
 
-	-- sortingAllowed tracks whether items can be moved between groups and sorted within groups.
-	-- Defaults to true but is turned off when the inventory window is open and the user hasn't
-	-- explicitly requested a resort.
-	self.sortingAllowed = true
-
-	-- Ensure items don't shift around when the window is open under normal usage.
-	-- self.forceResort can be used to override (usually when the user clicks the Resort button).
-	if
-		(
-			not self.resortNeeded
-			or self:Visible()
-		)
-		and not self.forceResort
-	then
-		-- self:PrintDebug("CategorizeAndSort() - sorting not allowed")
-		-- There was a change that would have triggered a resort, but it wasn't allowed, so enable the toolbar icon.
-		if self.resortNeeded then
-			self.enableResortIcon = true
-		end
-		-- Don't allow anything to move around; just update categorization.
-		self.sortingAllowed = false
-	end
-
-	-- self:PrintDebug("---------- CategorizeAndSort() PROCEEDING --------------")
-	-- self:PrintDebug("forceResort: " .. tostring(self.forceResort))
-	-- self:PrintDebug("visible: " .. tostring(self:Visible()))
-	-- self:PrintDebug("sortingAllowed: " .. tostring(self.sortingAllowed))
-
-	-- Reset force resort flag.
-	self.forceResort = false
-
-	-- Only refresh lookup tables when sorting can be performed.
-	if self.sortingAllowed then
-		self:UpdateLayoutLookupTables()
-
-		-- We're taking care of getting everything moved to the correct places now,
-		-- so the resort icon can be disabled.
-		self.enableResortIcon = false
-	end
-
 	-- Categorize items and assign to groups.
 	self:CategorizeItems()
-
-	-- Nothing more to do when items can't be moved.
-	if not self.sortingAllowed then
-		return
-	end
 
 	-- Sort items within groups.
 	self:SortGroups()
@@ -217,9 +258,6 @@ end
 --- - `categoriesToGroups` is exactly what it sounds like - the mapping of category IDs to group IDs (which are simply row:position)
 --- and is used by `CategorizeAndSort()` when filling the groupItems table.
 function Inventory:UpdateLayoutLookupTables()
-	if not self.sortingAllowed then
-		return
-	end
 	--self:PrintDebug("UpdateLayoutLookupTables()")
 	-- self:PrintDebug(BsCategories.list)
 
@@ -228,13 +266,12 @@ function Inventory:UpdateLayoutLookupTables()
 	local defaultCategoryFound = false
 
 	-- Wipe all the lookup tables managed by this function.
-	BsUtil.TableClear(self.groups)
-	BsUtil.TableClear(self.activeGroups)
-	BsUtil.TableClear(self.groupsIdsToFrames)
 	BsUtil.TableClear(self.activeCategoryIds)
-	BsUtil.TableClear(self.categorySequenceNumbers)
-	BsUtil.TableClear(self.sortedCategorySequenceNumbers)
+	BsUtil.TableClear(self.activeGroups)
 	BsUtil.TableClear(self.categoriesToGroups)
+	BsUtil.TableClear(self.categorySequenceNumbers)
+	BsUtil.TableClear(self.groups)
+	BsUtil.TableClear(self.sortedCategorySequenceNumbers)
 	-- Don't remove unused sequence number tables - no need to upset the garbage collector.
 	-- (This could be slightly more efficient with something like Compost, but it's not a huge deal.)
 	for _, categoryIds in pairs(self.categoryIdsGroupedBySequence) do
@@ -330,17 +367,15 @@ function Inventory:CategorizeItems()
 
 	-- groupItems stores the list of items that belongs to each group.
 	-- Start clean each time we categorize and sort.
-	-- This can only occur when items are allowed to be moved around!
-	if self.sortingAllowed then
-		-- groupItems is a table of tables, so only wipe the 2nd level tables to keep the garbage collector happy.
-		for groupId, _ in pairs(self.groupItems) do
-			BsUtil.TableClear(self.groupItems[groupId])
-		end
-		-- Using groups instead of activeGroups here just to ensure every possibility is initialized.
-		for groupId, _ in pairs(self.groups) do
-			if not self.groupItems[groupId] then
-				self.groupItems[groupId] = {}
-			end
+
+	-- groupItems is a table of tables, so only wipe the 2nd level tables to keep the garbage collector happy.
+	for groupId, _ in pairs(self.groupItems) do
+		BsUtil.TableClear(self.groupItems[groupId])
+	end
+	-- Using groups instead of activeGroups here just to ensure every possibility is initialized.
+	for groupId, _ in pairs(self.groups) do
+		if not self.groupItems[groupId] then
+			self.groupItems[groupId] = {}
 		end
 	end
 
@@ -367,33 +402,30 @@ function Inventory:CategorizeItems()
 						self.categoryIdsGroupedBySequence
 					)
 
-					-- Nothing more to do if we can't sort.
-					if self.sortingAllowed then
-						-- Fall back to the default group if one wasn't assigned.
-						groupId = self.inventory[bagNum][slotNum].bagshuiGroupId
-						if string.len(tostring(groupId or "")) == 0 then
-							groupId = defaultGroupId
-						end
-
-						-- Empty slots are now allowed to stack since they've been through the categorizing process.
-						-- (When an empty slot is first seen during a cache update, it gets the _bagshuiPreventEmptySlotStack
-						-- property set so that empty slots don't just "disappear" into a stack when the window is open
-						-- and the user moves an item out of a slot.)
-						if self.inventory[bagNum][slotNum].emptySlot == 1 then
-							self.inventory[bagNum][slotNum]._bagshuiPreventEmptySlotStack = nil
-						end
-
-						-- Final safety check to ensure we don't somehow try to assign to a group that doesn't exist.
-						if not self.groupItems[groupId] then
-							groupId = defaultGroupId
-						end
-
-						-- Add to group positions lookup table.
-						table.insert(
-							self.groupItems[groupId],
-							self.inventory[bagNum][slotNum]
-						)
+					-- Fall back to the default group if one wasn't assigned.
+					groupId = self.inventory[bagNum][slotNum].bagshuiGroupId
+					if string.len(tostring(groupId or "")) == 0 then
+						groupId = defaultGroupId
 					end
+
+					-- Empty slots are now allowed to stack since they've been through the categorizing process.
+					-- (When an empty slot is first seen during a cache update, it gets the _bagshuiPreventEmptySlotStack
+					-- property set so that empty slots don't just "disappear" into a stack when the window is open
+					-- and the user moves an item out of a slot.)
+					if self.inventory[bagNum][slotNum].emptySlot == 1 then
+						self.inventory[bagNum][slotNum]._bagshuiPreventEmptySlotStack = nil
+					end
+
+					-- Final safety check to ensure we don't somehow try to assign to a group that doesn't exist.
+					if not self.groupItems[groupId] then
+						groupId = defaultGroupId
+					end
+
+					-- Add to group positions lookup table.
+					table.insert(
+						self.groupItems[groupId],
+						self.inventory[bagNum][slotNum]
+					)
 
 				end -- bagNumSlots loop
 
@@ -494,6 +526,8 @@ function Inventory:UpdateWindow()
 
 	-- Only do the intensive work of redrawing the UI if we have to.
 	if self.windowUpdateNeeded then
+
+		BsUtil.TableClear(self.groupsIdsToFrames)
 
 		local uiFrames = self.ui.frames
 		local groupFrames = uiFrames.groups
@@ -637,7 +671,7 @@ function Inventory:UpdateWindow()
 
 		-- Reset tracking tables.
 		BsUtil.TableClear(self.groupItemCounts)  -- How many items are in each group.
-		BsUtil.TableClear(self.groupWidthsInItems)  -- Group width in items (actual count EXCEPT in Edit Mode, where 0 becomes 1 to force the group to be visible when empty)
+		BsUtil.TableClear(self.groupWidthsInItems)  -- Group width in items (actual count EXCEPT in Edit Mode, where 0 becomes 1 to force the group to be visible when empty).
 		BsUtil.TableClear(self.actualGroupWidths)  -- Group width in screen units.
 
 		-- Groups are placed starting at the bottom of the main frame and working upwards.
@@ -1147,7 +1181,6 @@ function Inventory:UpdateWindow()
 			-- WoW will change the anchor point to TOPLEFT when the frame is dragged, so we need to reset it.
 			self:FixWindowPosition()
 		end
-
 	end
 
 	-- Check for mouse over state for interact-able elements to ensure tooltips stay current.

--- a/Components/Inventory.lua
+++ b/Components/Inventory.lua
@@ -347,23 +347,27 @@ function Inventory:New(newPropsOrInventoryType)
 		postUpdateItemCounts = {},
 		lastUpdateLockedContainers = {},
 
-		-- Category/group-related lookup tables -- See CategorizeAndSort() for descriptions of most of these.
-		activeCategoryIds = {},
-		categoryIdsGroupedBySequence = {},
-		activeGroups = {},
-		categorySequenceNumbers = {},
-		sortedCategorySequenceNumbers = {},
-		categoriesToGroups = {},
+		-- Category/group-related lookup tables -- See `UpdateLayoutLookupTables()` for descriptions of most of these.
+		-- This is stored in the `currentLayoutState` table because there is a parallel `proposedLayoutState`
+		-- table used for dry-run calculations (automatically created during `Init()`).
+		currentLayoutState = {
+			activeCategoryIds = {},
+			activeGroups = {},
+			categoriesToGroups = {},
+			categoryIdsGroupedBySequence = {},
+			categorySequenceNumbers = {},
+			groupItems = {},
+			groups = {},
+			sortedCategorySequenceNumbers = {},
+		},
 
 		-- Tracking tables and state variables for UpdateWindow() and friends.
 		-- Detailed descriptions typically can be found where each is first referenced.
-		groups = {},
-		groupItems = {},
-		groupItemCounts = {},
-		groupWidthsInItems = {},
-		groupsIdsToFrames = {},
 		actualGroupWidths = {},
 		emptySlotStacks = {},  -- Fake item entries used to create empty slot stacks in the UI
+		groupItemCounts = {},
+		groupsIdsToFrames = {},
+		groupWidthsInItems = {},
 		expandEmptySlotStacks = false,
 		lastExpandEmptySlotStacks = false,
 		highlightItemsInContainerId = nil,
@@ -584,6 +588,13 @@ function Inventory:Init()
 	-- Activate profiles.
 	for _, profileType in pairs(BS_PROFILE_TYPE) do
 		self:SetProfile(self.settings["profile" .. profileType], profileType, true)
+	end
+
+	-- Prepare dry-run lookup tables and set initial lookup table pointers.
+	self.proposedLayoutState = {}
+	for key, _ in pairs(self.currentLayoutState) do
+		self.proposedLayoutState[key] = {}
+		self[key] = self.currentLayoutState[key]
 	end
 
 	-- Initialize settings.

--- a/Components/Inventory.lua
+++ b/Components/Inventory.lua
@@ -370,6 +370,7 @@ function Inventory:New(newPropsOrInventoryType)
 		groupWidthsInItems = {},
 		expandEmptySlotStacks = false,
 		lastExpandEmptySlotStacks = false,
+		hasSlotsWithStackingPrevented = false,  -- Whether any item in the cache has the `_bagshuiPreventEmptySlotStack` property set to `true` (managed by `UpdateCache()`).
 		highlightItemsInContainerId = nil,
 		highlightItemsInContainerLocked = false,
 		highlightItemsContainerSlot = nil,

--- a/Components/Util.lua
+++ b/Components/Util.lua
@@ -1206,9 +1206,15 @@ end
 ---@param obj2 any
 ---@param ignoreKeys table<string, true>? Table keys listed here (expressed in level1.level2.level3 notation) will not affect the outcome of the comparison.
 ---@param keyPath string? Recursion parameter for keeping track of the key path.
+---@param maxDepth number? Don't recurse tables any further than this (anything lower than 1 will just return `obj1 == obj2` immediately and is basically pointless).
 ---@return boolean equal
-function Util.ObjectsEqual(obj1, obj2, ignoreKeys, keyPath)
+function Util.ObjectsEqual(obj1, obj2, ignoreKeys, keyPath, maxDepth)
 	keyPath = keyPath or ""
+
+	-- Stop once maximum depth reached.
+	if type(maxDepth) == "number" and maxDepth <= 0 then
+		return obj1 == obj2
+	end
 
 	-- Same object.
 	if obj1 == obj2 then
@@ -1240,7 +1246,8 @@ function Util.ObjectsEqual(obj1, obj2, ignoreKeys, keyPath)
 					value1,
 					value2,
 					ignoreKeys,
-					keyPrefix .. key1
+					keyPrefix .. key1,
+					(type(maxDepth) == "number" and maxDepth - 1 or nil)
 				) == false
 			)
 		then


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail -->
Instead of just guessing whether the inventory needs to be categorized and sorted, actually determine it for a fact. During window updates, a proposed state is constructed and the Organize button only lights up if this differs from the current state.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please include a link (i.e. #issueNumber). -->
When a fully manual (bag#/slot# only) Sort Order is chosen, it was weird to have the Organize button constantly lighting up as items were moved, even though it wouldn't do anything. Now it behaves as expected since it knows whether clicking it would actually do anything or not.

## Testing
<!--- Please describe in detail how you tested your changes. -->
Verified Organize button correctly enables/disables when:
- New items are added to the inventory in a new slot (enabled)
- Items are added to an existing stack and there isn't an active Category that would cause it to move to a different Group (disabled)
- Items are added to an existing stack and there *is* an active Category that would cause it to move to a different Group (enabled)
- Restacking is invoked (enabled)
- Fully manual sorting is set (disabled)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Remove all that DON’T apply. -->
- New feature <!--- Non-breaking change that adds functionality -->