### PR TITLE
Add attachment handling for "old interface" Aux

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Bagshui Changelog
 
+## [1.4.6] - 2025-03-15
+### Fixed
+* Alt/Ctrl+click and right-click [compatibility](https://github.com/veechs/Bagshui/issues/118) with ["Old Interface" Aux](https://github.com/mrrosh/aux-addon_old-interface/). <sup><small>🪲 [@StrayDemon-13](https://github.com/StrayDemon-13)</small></sup>
+
 ## [1.4.5] - 2025-03-04
 ### Fixed
 * Picking up the Hearthstone by dragging the toolbar button [works again](https://github.com/veechs/Bagshui/issues/111). <sup><small>🪲 [@p3isman](https://github.com/p3isman)</small></sup>

--- a/Components/Inventory.Ui.ItemButton.lua
+++ b/Components/Inventory.Ui.ItemButton.lua
@@ -1006,6 +1006,39 @@ function Inventory:ItemButton_OnClick(mouseButton, isDrag)
 
 
 			elseif
+				-- "Old" Aux <https://github.com/mrrosh/aux-addon_old-interface/>.
+				-- Unlike the newer aux, old Aux has Alt/Control/Shift+click handling
+				-- but does *not* do right-click. It also hooks ContainerFrameItemButton_OnClick()
+				-- instead of UseContainerItem() so it really is totally different.
+				-- Must come before Blizzard Auction House because the old
+				-- version doesn't have its own frame and uses the Blizz one.
+				_G.IsAddOnLoaded("aux-addon")
+				and _G.AuxVersion
+				and _G.Aux
+				and _G.Aux_ContainerFrameItemButton_OnClick
+				and self.ui:IsFrameVisible("AuctionFrame")
+			then
+				if
+					mouseButton == "RightButton"
+					and self.settings.rightClickAttach
+				then
+					-- Make right-clicking behave like all other auction house right-clicks (send to Sell tab).
+					local oldGlobalThis = _G.this
+					local oldIsAltKeyDown = _G.IsAltKeyDown
+					_G.this = itemButton.bagshuiData.getIdProxy or _G.this  -- Have to force the use of the item button proxy for GetID()/GetParent():GetID().
+					_G.IsAltKeyDown = BsUtil.ReturnTrue
+					_G.ContainerFrameItemButton_OnClick("LeftButton")
+					_G.IsAltKeyDown = oldIsAltKeyDown
+					_G.this = oldGlobalThis
+
+				else
+					-- Let things fall through the normal path so `Aux_ContainerFrameItemButton_OnClick()`
+					-- will handle Alt/Control/Shift+click.
+					clickHandled = false
+				end
+
+
+			elseif
 				-- Blizzard Auction House - Right-click/Alt+click.
 				self:IsItemClickActionAllowed(mouseButton, "AuctionFrame")
 			then

--- a/Components/Inventory.Ui.ItemButton.lua
+++ b/Components/Inventory.Ui.ItemButton.lua
@@ -1027,7 +1027,7 @@ function Inventory:ItemButton_OnClick(mouseButton, isDrag)
 					local oldIsAltKeyDown = _G.IsAltKeyDown
 					_G.this = itemButton.bagshuiData.getIdProxy or _G.this  -- Have to force the use of the item button proxy for GetID()/GetParent():GetID().
 					_G.IsAltKeyDown = BsUtil.ReturnTrue
-					_G.ContainerFrameItemButton_OnClick("LeftButton")
+					_G.Aux_ContainerFrameItemButton_OnClick("LeftButton")
 					_G.IsAltKeyDown = oldIsAltKeyDown
 					_G.this = oldGlobalThis
 


### PR DESCRIPTION
<!--- Please provide a brief summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail -->
["Old Interface" Aux](https://github.com/mrrosh/aux-addon_old-interface/) has completely different attachment handling from the newer, more widely used version. It modifies the Blizzard AuctionFrame instead of creating its own UI from scratch, so in spite of it providing Alt+click, Bagshui wasn't allowing its code to execute and was acting as if the Blizzard Auction House was active instead. Since old Aux adds more tabs to the AH, this was causing the wrong tab to be activated.

Special detection of "old" Aux has been added so its attachment handling code will be used for Alt+click (and Ctrl+click), and Bagshui now knows how to provide right-click support.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please include a link (i.e. #issueNumber). -->
#118

## Testing
<!--- Please describe in detail how you tested your changes. -->
Verified all click combinations work as expected.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Remove all that DON’T apply. -->
- Bug fix <!--- Non-breaking change that resolves an issue -->
- New feature <!--- Non-breaking change that adds functionality -->