### PR TITLE
Bagshui 1.4.7

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Bagshui Changelog
 
+## 1.4.7 - 2025-03-26
+### Fixed
+* The first time a character logged in, [using Edit Mode in Bags would not change the Structure for Bank and vice-versa](https://github.com/veechs/Bagshui/issues/121). <sup><small>🪲 [@Szalor](https://github.com/Szalor)</small></sup>
+* Renaming a group could throw an error under certain circumstances.
+* Tooltips in Edit Mode for left-anchored inventory windows will no longer decide to be super wide.
+
 ## 1.4.6 - 2025-03-15
 ### Fixed
 * Alt/Ctrl+click and right-click [compatibility](https://github.com/veechs/Bagshui/issues/118) with ["Old Interface" Aux](https://github.com/mrrosh/aux-addon_old-interface/). <sup><small>🪲 [@StrayDemon-13](https://github.com/StrayDemon-13)</small></sup>

--- a/Components/Inventory.EditMode.lua
+++ b/Components/Inventory.EditMode.lua
@@ -537,8 +537,6 @@ function Inventory:RenameGroup(groupId, groupIsNew)
 			-- Clear text on hide so it doesn't bleed over to other dialogs.
 			OnHide = BsUtil.StaticPopupDialogs_ClearTextOnHide
 		}
-
-		self.renameGroup_Data = {}
 	end
 
 	-- Current group name and text to prompt user with.
@@ -555,6 +553,11 @@ function Inventory:RenameGroup(groupId, groupIsNew)
 	-- Lock group highlight so it's more clear what group is being renamed.
 	self.editModeGroupHighlight = groupId
 	self:EditModeWindowUpdate()
+
+	-- This seems to get removed sometimes so we'll make sure it stays.
+	if not self.renameGroup_Data then
+		self.renameGroup_Data = {}
+	end
 
 	-- Set properties we need the dialog scripts to know.
 	self.renameGroup_Data.groupId = groupId

--- a/Components/Inventory.Ui.ItemButton.lua
+++ b/Components/Inventory.Ui.ItemButton.lua
@@ -293,6 +293,7 @@ function Inventory:ItemButton_OnEnter(itemButton)
 	local gameTooltipAnchorPoint = BsUtil.FlipAnchorPoint(self.settings.windowAnchorXPoint)
 	local tooltipAnchorFrame = self.editMode and itemButton:GetParent() or itemButton
 	local tooltipOffset = BsSkin.tooltipExtraOffset
+	_G.GameTooltip:ClearAllPoints()
 	_G.GameTooltip:SetOwner(
 		itemButton,
 		-- Using ANCHOR_PRESERVE here for Edit Mode instead of ANCHOR_NONE

--- a/Components/Profiles.lua
+++ b/Components/Profiles.lua
@@ -137,6 +137,8 @@ local Profiles = Bagshui.prototypes.ObjectList:New({
 	defaults = Bagshui.config.Profiles.defaults,
 	wikiPage = BS_WIKI_PAGES.Profiles,
 
+	firstLoginCopies = {},
+
 	debugResetOnLoad = false and BS_DEBUG,
 })
 Bagshui.environment.BsProfiles = Profiles
@@ -383,14 +385,14 @@ function Profiles:GetUsableProfileId(profileId, profileType)
 
 	-- First fallback is a profile named after the current character.
 	local characterProfileId
-	if not self.list[profileId] then
+	if not profileId or not self.list[profileId] then
 		for existingProfileId, existingProfileInfo in pairs(self.list) do
 			if existingProfileInfo.name == Bagshui.currentCharacterId then
 				characterProfileId = existingProfileId
 			end
 		end
 	end
-	-- Only fall back to the character-named profile if it's not a first login.
+	-- Only immediately fall back to the character-named profile if it's not a first login.
 	if profileId and characterProfileId then
 		return characterProfileId
 	end
@@ -421,8 +423,17 @@ function Profiles:GetUsableProfileId(profileId, profileType)
 	local newProfileId
 	-- Don't try to create the same character profile multiple times.
 	if characterProfileId then
-		-- When the character profile already exists, overwrite this profile type's settings.
-		self:Copy(defaultProfileId, characterProfileId, profileTypeStorageKey)
+		-- On first login when cloning is needed, the character profile may have
+		-- already been created by another Inventory class instance or because a
+		-- different profile type was requested first. We need to be sure the
+		-- settings are correct, but also only set them once. Doing it multiple
+		-- times can mess up the pointer for the Inventory layout table until
+		-- the UI is reloaded (issue #121).
+		local fullId = characterProfileId .. profileTypeStorageKey
+		if not self.firstLoginCopies[fullId] then
+			self:Copy(defaultProfileId, characterProfileId, profileTypeStorageKey)
+			self.firstLoginCopies[fullId] = true
+		end
 		newProfileId = characterProfileId
 	else
 		-- Character profile doesn't exist yet.


### PR DESCRIPTION
## Description
* Keep Structure profiles in sync between Bags and Bank at first login.
* Renaming a group could throw an error under certain circumstances.
* Tooltips in Edit Mode for left-anchored inventory windows will no longer decide to be super wide.

## Motivation and context
#121 
+ random bugs

## Types of changes
- Bug fix <!--- Non-breaking change that resolves an issue -->