### PR TITLE
Display hidden items when bag highlight is locked

### DIFF
--- a/Bagshui.lua
+++ b/Bagshui.lua
@@ -880,8 +880,6 @@ function Bagshui:Init()
 
 	-- Need to adjust this by the scale so it behaves as expected.
 	BS_WINDOW_OFFSCREEN_RESCUE_THRESHOLD = BS_WINDOW_OFFSCREEN_RESCUE_THRESHOLD / _G.UIParent:GetScale()
-
-	self:PrintDebug(string.find("使用: 召唤或解散一只可供骑乘的机械陆行鸟", [[使用: 召唤和解散一..-可骑乘的]]))
 end
 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Bagshui Changelog
 
+## 1.4.10 - 2025-03-28
+### Fixed
+* Locking a bag's highlight via Alt+Click now [temporarily unhides all items in that bag](https://github.com/veechs/Bagshui/issues/125). <sup><small>🪲 [@RetroCro](https://github.com/RetroCro)</small></sup>
+
 ## 1.4.9 - 2025-03-27
 ### Changed
 * zh-CN localization updates by [@Sunelegy](https://github.com/Sunelegy).

--- a/Components/Inventory.Layout.lua
+++ b/Components/Inventory.Layout.lua
@@ -638,8 +638,12 @@ function Inventory:UpdateWindow()
 
 					-- Determine how many items are in each group in this row based on group visibility.
 					if not self.editMode and not self.showHidden and hideGroup then
-						-- Set the groupItemCounts for this group to 0 if it's not visible.
-						self.groupItemCounts[groupId] = 0
+						-- Set the groupItemCounts for this group to 0 if it's not visible unless it contains
+						-- items from the bag that has highlight lock set.
+						self.groupItemCounts[groupId] =
+							self.highlightItemsInContainerLocked
+							and self:GetGroupItemCountForLayout(groupId, self.highlightItemsInContainerLocked)
+							or 0
 					else
 						self.groupItemCounts[groupId] = self:GetGroupItemCountForLayout(groupId)
 					end
@@ -1240,7 +1244,12 @@ function Inventory:AssignItemsToSlots(
 			end
 
 			-- Determine whether this item is hidden.
-			if not self.editMode and not self.showHidden and self.hideItems[item.id] then
+			if
+				not self.editMode
+				and not self.showHidden
+				and self.highlightItemsInContainerLocked ~= item.bagNum  -- Unhide items when bag highlighting is locked on.
+				and self.hideItems[item.id]
+			then
 				hideItem = true
 			end
 
@@ -1349,8 +1358,9 @@ end
 --- Return the number of items in a group that will be visible, accounting for stacked slots and hidden items.  
 --- Also updates `self.hasHiddenItems`.
 ---@param groupId number ID of group to get the number of items for.
+---@param zeroUnlessHasItemsInBagNum number? Return 0 unless the group has items that are in the specified bag number -- in that case, return the normal count.
 ---@return integer visibleItemCount
-function Inventory:GetGroupItemCountForLayout(groupId)
+function Inventory:GetGroupItemCountForLayout(groupId, zeroUnlessHasItemsInBagNum)
 	-- No items.
 	if not self.groupItems[groupId] then
 		return 0
@@ -1365,6 +1375,7 @@ function Inventory:GetGroupItemCountForLayout(groupId)
 	local visibleItemCount = 0
 	local itemVisible
 	local hasEmptySlots = false
+	local hasItemsInFilterBag = false
 
 	-- We'll be using the permanent self.emptySlotStacks items, so reset their counts first.
 	self:ResetEmptySlotStackCounts()
@@ -1373,6 +1384,11 @@ function Inventory:GetGroupItemCountForLayout(groupId)
 	for _, item in ipairs(self.groupItems[groupId]) do
 		-- Assume the item will be counted
 		itemVisible = true
+
+		-- Have we found an item in the bag that will require a full count to be returned?
+		if zeroUnlessHasItemsInBagNum and item.bagNum == zeroUnlessHasItemsInBagNum then
+			hasItemsInFilterBag = true
+		end
 
 		-- Empty slot stacks and hidden items.
 		if self:UpdateEmptySlotStackCount(item) then
@@ -1389,7 +1405,11 @@ function Inventory:GetGroupItemCountForLayout(groupId)
 			-- We need to update hasHiddenItems even if we're not actually hiding this item so that the toolbar icon will be enabled.
 			self.hasHiddenItems = true
 			-- Need to count the item when in Edit Mode or hidden items are shown.
-			itemVisible = (self.editMode or self.showHidden)
+			itemVisible = (
+				self.editMode
+				or self.showHidden
+				or self.highlightItemsInContainerLocked == item.bagNum
+			)
 		end
 
 		-- Increment count if visible.
@@ -1405,6 +1425,11 @@ function Inventory:GetGroupItemCountForLayout(groupId)
 				visibleItemCount = visibleItemCount + 1
 			end
 		end
+	end
+
+	-- We were asked for a full count ONLY If this group has items in a specific bag.
+	if zeroUnlessHasItemsInBagNum and not hasItemsInFilterBag then
+		return 0
 	end
 
 	return visibleItemCount

--- a/Components/Inventory.Ui.BagButton.lua
+++ b/Components/Inventory.Ui.BagButton.lua
@@ -240,9 +240,9 @@ function InventoryUi:CreateBagSlotButtons()
 				)
 				and not inventory.editMode
 			then
+				local oldHighlightItemsInContainerLocked = inventory.highlightItemsInContainerLocked
 
-				-- Toggle highlight lock for this button
-				-- this.bagshuiData.highlightLocked = not this.bagshuiData.highlightLocked
+				-- Toggle highlight lock for this button.
 				inventory.highlightItemsInContainerLocked =
 					inventory.highlightItemsInContainerLocked ~= bagNum
 					and bagNum
@@ -250,7 +250,13 @@ function InventoryUi:CreateBagSlotButtons()
 
 				inventory.highlightItemsInContainerId = bagNum
 				inventory:UpdateBagBar()
-				inventory:UpdateItemSlotColors()
+				-- When the highlight lock is changed, we need to do a full window update
+				-- so hidden items in this bag can be shown or hidden.
+				if oldHighlightItemsInContainerLocked ~= inventory.highlightItemsInContainerLocked then
+					inventory:ForceUpdateWindow()
+				else
+					inventory:UpdateItemSlotColors()
+				end
 
 				-- Don't pick up bag or do anything else if alt key was down.
 				if _G.IsAltKeyDown() then


### PR DESCRIPTION
## Description
Avoid the apparent "phantom" items that can occur when a bag contains hidden items by revealing them when the slot highlight is locked via Alt+Click.

## Motivation and context
#125

## Types of changes
- Bug fix <!--- Non-breaking change that resolves an issue -->