### PR TITLE
Prevent error when trying to unequip a tabard

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 # Bagshui Changelog
 
-## 1.5.0 - 2025-03-29
+## 1.5.1 - 2025-04-06
+### Fixed
+* Prevent [error when unequipping a tabard](https://github.com/veechs/Bagshui/issues/130). <sup><small>🪲 bonho</small></sup>
+
+## 1.5.0 - 2025-04-05
 ### Changes
 * **Automated bag swapping**<br>One of the most-requested features! Just equip a new bag and Bagshui [takes care of the rest](https://github.com/veechs/Bagshui/wiki/FAQ#how-do-i-swap-bags-when-i-get-bigger-ones).<br><sup><small>Sufficient free space is required, but you can visit the Bank to supplement without cleaning your Bags.</small></sup><br><sup><small>🫶&nbsp;[@Nikki1993](https://github.com/Nikki1993), Kralomax, and everyone on the TW Discord who has asked</small></sup>
 * **Shiny new toolbar buttons**<br>**Clam** (Open Container), **Disenchant**, and **Pick Lock**. <sup><small>🫶&nbsp;[@melbaa](https://github.com/melbaa), [@Azzc0](https://github.com/Azzc0)</small>

--- a/Components/Bagshui.Cursor.lua
+++ b/Components/Bagshui.Cursor.lua
@@ -281,6 +281,7 @@ end
 ---@param invSlotId number Inventory slot ID to pick up the item from.
 ---@return any wowApiFunctionReturnValue Return value from hooked WoW API function.
 function Bagshui:PickupInventoryItem(wowApiFunctionName, invSlotId)
+	--self:PrintDebug("Bagshui:PickupInventoryItem() called from " .. tostring(wowApiFunctionName) .. " with invSlotId " .. tostring(invSlotId))
 
 	-- Only store bag slot information if there's currently a bag on the cursor
 	-- and the destination is different from the source.
@@ -326,12 +327,15 @@ function Bagshui:PickupInventoryItem(wowApiFunctionName, invSlotId)
 					and self.components[inventoryType].inventoryIdsToContainerIds
 					and self.components[inventoryType].inventoryIdsToContainerIds[invSlotId]
 				then
+					--self:PrintDebug("> " .. inventoryType .. " has matching invSlotId for bag slot")
 					self.cursorBagSlotNum = invSlotId
 					break
 				end
 			end
 		end
 	end
+
+	--self:PrintDebug("> cursorBagSlotNum is now " .. tostring(self.cursorBagSlotNum))
 
 	-- PutItemInBag() doesn't trigger any of our normal cursor clearing methods,
 	-- so a manual check on the next frame is needed to ensure accuracy.

--- a/Components/Bagshui.Cursor.lua
+++ b/Components/Bagshui.Cursor.lua
@@ -118,7 +118,7 @@ function Bagshui:PickupItem(item, inventoryClass, itemSlotButton, callPickupCont
 			self:PrintDebug(self.cursorBagSlotNum)
 			self:PrintDebug(inventoryClass.inventoryIdsToContainerIds[self.cursorBagSlotNum])
 			local bagNum = inventoryClass.inventoryIdsToContainerIds[self.cursorBagSlotNum]
-			if inventoryClass.containers[bagNum].slotsFilled > 0 then
+			if bagNum and inventoryClass.containers[bagNum].slotsFilled > 0 then
 				-- Bag needs to be emptied before it can be unequipped.
 				if inventoryClass:GetAdjustedEmptySlotCount(bagNum) > inventoryClass.containers[bagNum].slotsFilled then
 					-- Empty the bag.

--- a/Components/Inventory.lua
+++ b/Components/Inventory.lua
@@ -487,8 +487,11 @@ function Inventory:New(newPropsOrInventoryType)
 	classObj.inventoryTypeLocalized = L[classObj.inventoryType]
 
 	-- Build the list of containerIds belonging to this class along with the reverse inventory ID (slot) mapping.
-	for index, containerId in ipairs(classObj.containerIds) do
+	-- Starting at index 2 because primary containers are never inventory slots into which bags can be equipped.
+	for index = 2, table.getn(classObj.containerIds) do
+		local containerId = classObj.containerIds[index]
 		classObj.myContainerIds[containerId] = index
+		--Bagshui:PrintDebug(classObj.inventoryType .. " container " .. containerId .. " is inventoryId " .. _G.ContainerIDToInventoryID(containerId))
 		classObj.inventoryIdsToContainerIds[_G.ContainerIDToInventoryID(containerId)] = containerId
 	end
 

--- a/Readme.md
+++ b/Readme.md
@@ -69,6 +69,9 @@ Use [GitAddonsManager](https://woblight.gitlab.io/overview/gitaddonsmanager/).
 
 ## Compatibility
 
+
+### Functionality
+
 <table>
 
 <tr>
@@ -155,6 +158,16 @@ Use [GitAddonsManager](https://woblight.gitlab.io/overview/gitaddonsmanager/).
 <sup>If installed, [SuperWoW](https://github.com/balakethelock/SuperWoW) provides charge counts (the `×#` overlay for multi-use items) slightly more efficiently. This is pretty minor since you'll have the functionality regardless.</sup>
 
 
+### Languages
+
+If Bagshui has not been localized for your client, many items will not be correctly identified by the built-in categorization[^1]. Please consider [contributing a translation](Localization/Readme.md) if you'd like to have full functionality!
+
+* English (enUS)
+* Chinese (zhCN)
+
+[^1]: In Vanilla, a *lot* of item identification must be done either by parsing tooltips or hardcoding item IDs. Bagshui leans toward the former, and therefore is highly dependent on localization.
+
+
 ## Donations
 Developing Bagshui is fun, but also a lot of work! Your support is hugely appreciated.  
 <a href="https://www.buymeacoffee.com/veechs" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-orange.png" alt="Buy Me A Coffee" height="41" width="146"></a>
@@ -164,7 +177,3 @@ Developing Bagshui is fun, but also a lot of work! Your support is hugely apprec
 
 Bagshui owes [so much to so many people](Credits.md).
 
-
-## Localization
-
-Translations welcome! [Instructions here](Localization/Readme.md).


### PR DESCRIPTION
## Description
Exclude primary containers from inventory slot ID mapping since they don't have one.

## Motivation and context
This incorrect inclusion was causing #130.

## Types of changes
- Bug fix <!--- Non-breaking change that resolves an issue -->