### PR TITLE
Prevent items from getting stuck in locked (gray) state

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Bagshui Changelog
 
+## 1.5.3 - 2025-04-12
+### Fixed
+* Prevent [items from getting stuck in locked (grayed-out) state](https://github.com/veechs/Bagshui/issues/138). <sup><small>🪲&nbsp;[@Szalor](https://github.com/Szalor)</small></sup>
+
 ## 1.5.2 - 2025-04-06
 ### Fixed
 * Avoid [error from Manage Character Data window](https://github.com/veechs/Bagshui/issues/132) when a character has never logged out. <sup><small>🪲&nbsp;[@Szalor](https://github.com/Szalor)</small></sup>

--- a/Components/Inventory.Layout.lua
+++ b/Components/Inventory.Layout.lua
@@ -159,9 +159,9 @@ function Inventory:ManageDryRun(phase1)
 			and not self.forceResort
 		then
 			self.dryRun = true
-			self:PrintDebug("++++DRY RUN ON++++")
-		else
-			self:PrintDebug("----dry run off----")
+		-- 	self:PrintDebug("++++DRY RUN ON++++")
+		-- else
+		-- 	self:PrintDebug("----dry run off----")
 		end
 
 		-- Reset force resort flag.

--- a/Components/Inventory.lua
+++ b/Components/Inventory.lua
@@ -487,13 +487,15 @@ function Inventory:New(newPropsOrInventoryType)
 	classObj.inventoryTypeLocalized = L[classObj.inventoryType]
 
 	-- Build the list of containerIds belonging to this class along with the reverse inventory ID (slot) mapping.
-	-- Starting at index 2 because primary containers are never inventory slots into which bags can be equipped.
-	for index = 2, table.getn(classObj.containerIds) do
+	for index = 1, table.getn(classObj.containerIds) do
 		local containerId = classObj.containerIds[index]
 		classObj.myContainerIds[containerId] = index
-		--Bagshui:PrintDebug(classObj.inventoryType .. " container " .. containerId .. " is inventoryId " .. _G.ContainerIDToInventoryID(containerId))
-		classObj.inventoryIdsToContainerIds[_G.ContainerIDToInventoryID(containerId)] = containerId
+		-- Starting inventory ID mapping at index 2 because primary containers are never inventory slots into which bags can be equipped.
+		if index > 1 then
+			classObj.inventoryIdsToContainerIds[_G.ContainerIDToInventoryID(containerId)] = containerId
+		end
 	end
+
 
 	-- Store docked inventory relationship.
 	if classObj.dockTo and Bagshui.components[classObj.dockTo] then

--- a/Components/Inventory.lua
+++ b/Components/Inventory.lua
@@ -384,7 +384,6 @@ function Inventory:New(newPropsOrInventoryType)
 		hasChanges = false,
 		highlightChangesEnabled = false,
 		hasOpenables = false,
-		lockedItemCount = 0,  -- Used during cache updates to try and ensure we catch all lock changes.
 		nextOpenableItemBagNum = nil,
 		nextOpenableItemSlotNum = nil,
 		nextOpenableItemSlotButton = nil,
@@ -648,26 +647,12 @@ end
 
 
 
--- Reusable variables for Inventory:OnEvent() to reduce GC load during event storms.
-
-local onEvent_action, onEvent_updateDelay
-
-
 --- Event handling.
 ---@param event string Event identifier.
 ---@param arg1 any? Argument 1 from the event.
 ---@param arg2 any? Argument 2 from the event.
 function Inventory:OnEvent(event, arg1, arg2)
-	self:PrintDebug("OnEvent(): " ..  event .. " // " .. tostring(arg1) .. " // " .. tostring(arg2))
-
-	-- Let the default delay for a queued update apply most of the time.
-	onEvent_updateDelay = nil
-
-	-- We need a small delay when there's a locked item because sometimes BAG_UPDATE comes so soon
-	-- after an item is locked that we don't have time to find out it's unlocked.
-	if self.lastEvent == "ITEM_LOCK_CHANGED" and event == "BAG_UPDATE" then
-		onEvent_updateDelay = 0.15
-	end
+	-- self:PrintDebug("OnEvent(): " ..  event .. " // " .. tostring(arg1) .. " // " .. tostring(arg2))
 
 	-- Store the name of this event so it can be checked when updating the inventory
 	-- cache to see if the cache update should be delayed (see self.lastEvent check
@@ -779,17 +764,17 @@ function Inventory:OnEvent(event, arg1, arg2)
 
 
 	-- Special action handling - see description of the Events table in Inventory:New() for details.
-	onEvent_action = self.events[event]
+	local eventAction = self.events[event]
 
 	-- Re-queue the event with a delay if configured.
-	if type(onEvent_action) == "number" then
-		Bagshui:QueueEvent("BAGSHUI_"..event, onEvent_action, false, arg1, arg2)
+	if type(eventAction) == "number" then
+		Bagshui:QueueEvent("BAGSHUI_"..event, eventAction, false, arg1, arg2)
 		return
 	end
 
 	-- Call the event function if it exists.
 	-- If the function returns false, don't continue processing.
-	local eventFunction = self[onEvent_action]
+	local eventFunction = self[eventAction]
 	if type(eventFunction) == "function" then
 		if eventFunction(self) == false then
 			return
@@ -884,6 +869,7 @@ function Inventory:OnEvent(event, arg1, arg2)
 		return
 	end
 
+
 	-- Lock/unlock events need a cache update, but not when a container has
 	-- been picked up.
 	if
@@ -891,15 +877,15 @@ function Inventory:OnEvent(event, arg1, arg2)
 		and not Bagshui.pickedUpBagSlotNum
 		and not Bagshui.putDownBagSlotNum
 	then
-		self:PrintDebug("will force cache update")
 		self.forceCacheUpdate = true
 	end
+
 
 	-- Assume any other event that gets this far may require a cache update.
 	self.cacheUpdateNeeded = true
 
 	-- If we get this far, it's a normal event that should just trigger inventory and window updates.
-	self:QueueUpdate(onEvent_updateDelay)
+	self:QueueUpdate()
 end
 
 


### PR DESCRIPTION
## Description
A change in Bagshui 1.5.2 introduced a new bug where items in the primary container (i.e. Backpack, Bank vault, Keyring) wouldn't update properly when moved or sold, requiring another event to trigger a full refresh and get them unstuck.

## Motivation and context
#138

## Types of changes
- Bug fix <!--- Non-breaking change that resolves an issue -->