### PR TITLE
Keep Alt+click bag highlights on when items picked up

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Bagshui Changelog
 
+## 1.5.4 - 2025-04-12
+### Fixed
+* Ensure Alt+click bag highlights [persist correctly](https://github.com/veechs/Bagshui/issues/141).
+
 ## 1.5.3 - 2025-04-12
 ### Fixed
 * Prevent [items from getting stuck in locked (grayed-out) state](https://github.com/veechs/Bagshui/issues/138). <sup><small>🪲&nbsp;[@Szalor](https://github.com/Szalor)</small></sup>

--- a/Components/Inventory.Actions.lua
+++ b/Components/Inventory.Actions.lua
@@ -56,14 +56,16 @@ end
 ---@param itemButton table? If provided, call OnEnter for this item button to update the tooltip.
 ---@param noUpdate boolean? Don't call `Inventory:UpdateItemSlotColors()`.
 function Inventory:ClearItemPendingSale(itemButton, noUpdate)
-	self.itemPendingSale = nil
-	self.highlightItemsInContainerId = nil
-	self.highlightItemsContainerSlot = nil
-	if itemButton then
-		self:ItemButton_OnEnter(itemButton)
-	end
-	if not noUpdate then
-		self:UpdateItemSlotColors()
+	if self.itemPendingSale then
+		self.itemPendingSale = nil
+		self.highlightItemsInContainerId = nil
+		self.highlightItemsContainerSlot = nil
+		if itemButton then
+			self:ItemButton_OnEnter(itemButton)
+		end
+		if not noUpdate then
+			self:UpdateItemSlotColors()
+		end
 	end
 end
 


### PR DESCRIPTION
## Description
Bagshui 1.5 introduced a bug where picking up any item would incorrectly reset the Alt+click bag slot highlighting.

## Motivation and context
#141

## Types of changes
- Bug fix <!--- Non-breaking change that resolves an issue -->
