### PR TITLE
pfUI cooldown compatibility improvements

### DIFF
--- a/Bagshui.lua
+++ b/Bagshui.lua
@@ -735,7 +735,14 @@ local bagshuiEnvironment = {
 	type = _G.type,
 
 	-- Other addons.
-	pfUI = _G.IsAddOnLoaded("pfUI") and _G.pfUI or nil,
+	-- Intensive check for pfUI to ensure it's the real thing and not an addon that
+	-- provides pfUI API compatibility. (And false is used since nil will just
+	-- end up with an empty table entry and it will metatable its way up into _G).
+	pfUI = (
+		_G.IsAddOnLoaded("pfUI")
+		and _G.pfUI and _G.pfUI.uf 
+		and _G.pfUI.env and _G.pfUI.env.C
+	) and _G.pfUI or false,
 
 
 	-- Contain the _ dummy variable within the Bagshui environment.

--- a/Components/Ui.ItemButton.lua
+++ b/Components/Ui.ItemButton.lua
@@ -199,10 +199,9 @@ end
 function Ui:CreateItemButtonCooldown(button, disableText)
 	local cooldown = _G.CreateFrame("Model", button:GetName() .. "Cooldown", button, "CooldownFrameTemplate")
 	cooldown:SetFrameLevel(cooldown:GetFrameLevel() + 1)  -- Move above NormalTexture.
-	-- Enable pfUI cooldown display. The pfUI check is needed because
-	-- Turtle Dragonflight will double the text when pfCooldownType is present.
-	-- (`pfUI` is added to the Bagshui environment in Bagshui.lua).
-	if pfUI then
+	-- Pretend we're a pfUI frame so we can get pfUI cooldown text without the 
+	-- "Foreign Frames" option (so long as the pfUI cooldown module is enabled).
+	if pfUI and pfUI.env.C.disabled and pfUI.env.C.disabled.cooldown ~= "1" then
 		cooldown.pfCooldownType = "ALL"
 	end
 	return cooldown


### PR DESCRIPTION
## Description
- Don't add the pfCooldownType property to item frames unless pfUI really is loaded and the cooldown module is enabled.
- Improve accuracy of "pfUI really is loaded" detection.

## Motivation and context
#143

## Testing
* Enabled ShaguPlates, ShaguTweaks, and pfQuest. Reproduced the doubled cooldown text bug with 1.5.4.
* Applied fix and verified the issue no longer occurs.

## Types of changes
- Bug fix <!--- Non-breaking change that resolves an issue -->
