### PR TITLE
Update Recipes category for Turtle WoW weirdness

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Bagshui Changelog
 
+## 1.5.5 - 2025-04-15
+### Fixed
+* Prevent [doubled cooldown text](https://github.com/veechs/Bagshui/issues/143) when ShaguPlates, ShaguTweaks, and pfQuest are enabled. Thanks to [@shagu](https://github.com/shagu) for identifying the cause and suggesting how to fix it. <sup><small>🪲&nbsp;[@Vymya](https://github.com/Vymya)</small></sup>
+* Capture custom Turtle WoW recipes that are [wrongly categorized on the server side](https://github.com/veechs/Bagshui/issues/144). <sup><small>🗃️&nbsp;[@Szalor](https://github.com/Szalor)</small></sup>
+
 ## 1.5.4 - 2025-04-12
 ### Fixed
 * Ensure Alt+click bag highlights [persist correctly](https://github.com/veechs/Bagshui/issues/141).

--- a/Config/Categories.lua
+++ b/Config/Categories.lua
@@ -287,8 +287,9 @@ Bagshui.config.Categories = {
 			-- 3. The "Top/Bottom Half of Advanced..." pieces need to be captured.
 			sequence = 66,
 			rule = string.format(
-				'Type("%s")\nor\n(\n  Name("/^%s/", "/^%s/")\n  and Subtype("%s", "%s")\n)',
+				'Type("%s")\nor Tooltip("%s")\nor\n(\n  Name("/^%s/", "/^%s/")\n  and Subtype("%s", "%s")\n)',
 				L.Recipe,
+				L.TooltipIdentifier_Recipe,
 				L.NameIdentifier_Recipe_TopHalf,
 				L.NameIdentifier_Recipe_BottomHalf,
 				L.Junk,

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -516,6 +516,7 @@ BsLocalization:AddLocale("enUS", {
 ["TooltipIdentifier_PotionHealth"] = [[/Restores %d+ to %d+ health\./]],  -- Wrap in slashes to activate pattern matching.
 ["TooltipIdentifier_PotionMana"] = [[/Restores %d+ to %d+ mana\./]],  -- Wrap in slashes to activate pattern matching.
 ["TooltipIdentifier_QuestItem"] = [[Quest Item]],
+["TooltipIdentifier_Recipe"] = [[Use: Teaches you how to]],  -- Needed because Turtle WoW has some of their custom recipes categorized as Consumables.
 ["TooltipIdentifier_ToyTurtleWoW"] = [[Use: Add a toy to the player's toy collection]],
 
 -- Tooltip parsing -- extracting data from tooltips.

--- a/Locale/zhCN.lua
+++ b/Locale/zhCN.lua
@@ -501,6 +501,7 @@ BsLocalization:AddLocale("zhCN", {
 ["TooltipIdentifier_PotionHealth"] = [[/恢复%d+到%d+点生命值\。/]],  -- 用斜杠包裹以激活模式匹配。
 ["TooltipIdentifier_PotionMana"] = [[/恢复%d+到%d+点法力值\。/]],  -- 用斜杠包裹以激活模式匹配。
 ["TooltipIdentifier_QuestItem"] = [[任务物品]],
+["TooltipIdentifier_Recipe"] = [[使用: 教你学会制]],
 ["TooltipIdentifier_ToyTurtleWoW"] = [[使用..-将玩具添加到玩家的玩具收藏中]],
 
 -- Tooltip parsing -- extracting data from tooltips.


### PR DESCRIPTION
## Description
Turtle has some custom recipes with type Consumable instead of Recipe, so a tooltip check has been added to the Recipes category.

## Motivation and context
#144

## Types of changes
- Item categorization
