### PR TITLE
Don't escape magic characters for equals tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Bagshui Changelog
 
+## 1.5.6 - 2025-04-26
+### Fixed
+* Matching item properties that contain Lua pattern characters (most notably `-` but could be any of `^$()%.[]*+-?`) [now works as it should](https://github.com/veechs/Bagshui/issues/149). <sup><small>🪲&nbsp;[@AsunaSalata](https://github.com/AsunaSalata)</small></sup>
+
 ## 1.5.5 - 2025-04-15
 ### Fixed
 * Prevent [doubled cooldown text](https://github.com/veechs/Bagshui/issues/143) when ShaguPlates, ShaguTweaks, and pfQuest are enabled. Thanks to [@shagu](https://github.com/shagu) for identifying the cause and suggesting how to fix it. <sup><small>🪲&nbsp;[@Vymya](https://github.com/Vymya)</small></sup>

--- a/Components/Rules.lua
+++ b/Components/Rules.lua
@@ -490,7 +490,7 @@ function Rules:TestValue(
 		matchType = BS_RULE_MATCH_TYPE.EQUALS
 	end
 
-	-- Validate validArgumentTypes by removing any spaces and uppercasing everything
+	-- Validate validArgumentTypes by removing any spaces and uppercasing everything.
 	validArgumentTypes = validArgumentTypes and string.gsub(string.upper(tostring(validArgumentTypes)), "%s", "")
 
 	-- Only permit numbers for "between" comparisons.
@@ -607,7 +607,11 @@ function Rules:TestValue(
 					)
 				else
 					-- String literal -- just lowercase it.
-					argument = string.lower(BsUtil.EscapeMagicCharacters(argument))
+					argument = string.lower(argument)
+					-- Also need to escape pattern characters if this will be run through `string.find()`.
+					if matchType == BS_RULE_MATCH_TYPE.CONTAINS then
+						argument = BsUtil.EscapeMagicCharacters(argument)
+					end
 				end
 			end
 

--- a/Config/RuleFunctions.lua
+++ b/Config/RuleFunctions.lua
@@ -965,8 +965,8 @@ Bagshui.config.RuleFunctions = {
 		},
 		ruleFunction = function(rules, ruleArguments)
 			return (
-				rules:TestValue(BsGameInfo.currentSubZone, ruleArguments, nil, BS_RULE_MATCH_TYPE.CONTAINS, nil, nil, true)
-				or rules:TestValue(BsGameInfo.currentMinimapZone, ruleArguments, nil, BS_RULE_MATCH_TYPE.CONTAINS, nil, nil, true)
+				rules:TestValue(BsGameInfo.currentSubZone, ruleArguments, nil, "contains", nil, nil, true)
+				or rules:TestValue(BsGameInfo.currentMinimapZone, ruleArguments, nil, "contains", nil, nil, true)
 			)
 		end,
 		-- Template come from localization.
@@ -1146,8 +1146,8 @@ Bagshui.config.RuleFunctions = {
 		},
 		ruleFunction = function(rules, ruleArguments)
 			return (
-				rules:TestValue(BsGameInfo.currentZone, ruleArguments, nil, BS_RULE_MATCH_TYPE.CONTAINS, nil, nil, true)
-				or rules:TestValue(BsGameInfo.currentRealZone, ruleArguments, nil, BS_RULE_MATCH_TYPE.CONTAINS, nil, nil, true)
+				rules:TestValue(BsGameInfo.currentZone, ruleArguments, nil, "contains", nil, nil, true)
+				or rules:TestValue(BsGameInfo.currentRealZone, ruleArguments, nil, "contains", nil, nil, true)
 			)
 		end,
 		-- Template come from localization.


### PR DESCRIPTION
## Description
Overzealous magic character escaping was breaking value equals tests if there was a pattern character. (For example, "one-handed maces" became "one%-handed maces", causing a `Subtype()` rule to fail).

## Motivation and context
#149

## Types of changes
- Bug fix <!--- Non-breaking change that resolves an issue -->
