### PR TITLE
Prevent lag in raid groups by adjusting character events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Bagshui Changelog
 
+## 1.5.10 - 2025-04-26
+### Fixed
+* Prevent lag while in a raid group. Additional protections for in-combat performance are being tested, but this should resolve the worst of the [issues](https://github.com/veechs/Bagshui/issues/153). Thanks to jj for their patient testing that helped me locate the root cause.
+
 ## 1.5.9 - 2025-04-26
 ### Fixed
 * Avoid localization errors. Whoops (x2).

--- a/Components/Character.lua
+++ b/Components/Character.lua
@@ -30,8 +30,7 @@ local CHARACTER_EVENTS = {
 	SKILL_LINES_CHANGED = true,  -- Need to update skills (needed to catch some weird skills like Fist Weapons).
 	SPELLS_CHANGED = true,  -- Need to update spells.
 	TRADE_SKILL_SHOW = true,  -- Profession window is opened (other than Enchanting).
-	UPDATE_INVENTORY_ALERTS = true,  -- Equipped gear has changed.
-	UNIT_INVENTORY_CHANGED = true,  -- Equipped gear has changed.
+	UNIT_INVENTORY_CHANGED = true,  -- Equipped gear has changed -- requires arg1 == "player" check.
 }
 
 -- Events that should trigger a money update.
@@ -157,7 +156,7 @@ Bagshui.components.Character = Character
 ---@param event string WoW API event
 ---@param arg1 any First event argument.
 function Character:OnEvent(event, arg1)
-	-- Bagshui:PrintDebug("Character event " .. event .. " // " .. tostring(arg1))
+	Bagshui:PrintDebug("Character event " .. event .. " // " .. tostring(arg1))
 
 	-- Initial processing at startup. The delayed event is necessary to ensure
 	-- we can actually get the data we need, which isn't available instantly.
@@ -167,6 +166,18 @@ function Character:OnEvent(event, arg1)
 		if not self.initialized then
 			Bagshui:QueueEvent("BAGSHUI_INITIAL_CHARACTER_UPDATE", 1.5)
 		end
+		return
+	end
+
+	-- Set Character things up at login.
+	if event == "BAGSHUI_INITIAL_CHARACTER_UPDATE" then
+		self:UpdateSkillsAndSpells()
+		self:UpdateGear()
+		self:UpdateMoney()
+		-- Need to set this true before calling UpdateInfo() so that it will
+		-- correctly raise BAGSHUI_CHARACTER_UPDATE.
+		self.initialized = true
+		self:UpdateInfo()
 		return
 	end
 
@@ -182,54 +193,37 @@ function Character:OnEvent(event, arg1)
 		return
 	end
 
-	-- Refresh spells/skills and remove any items from the profession tables that shouldn't be there anymore.
-	-- This is also where the initial update after PLAYER_ENTERING_WORLD occurs.
-	if
-		(
-			self.initialized
-			and (
-				event == "SPELLS_CHANGED"
-				or event == "CHAT_MSG_SKILL"
-				or event == "SKILL_LINES_CHANGED"
-			)
-		)
-		or event == "BAGSHUI_INITIAL_CHARACTER_UPDATE"
-	then
-		self:UpdateSkillsAndSpells()
-		self:PruneProfessionItems()
-		-- Need to set this true before calling UpdateInfo() so that it will
-		-- correctly raise BAGSHUI_CHARACTER_UPDATE.
-		self.initialized = true
-		if event == "BAGSHUI_INITIAL_CHARACTER_UPDATE" then
-			self:UpdateInfo()
-			self:UpdateGear()
-			self:UpdateMoney()
-		end
-		-- Whenever something major about the character changes, the usable cache must be updated.
-		-- This might be slightly overboard, but it's the easiest way to maximize
-		-- accuracy of usability status.
-		BsItemInfo:InvalidateUsableCache()
-		return
-	end
-
 	-- Nothing else can happen until the class is initialized.
 	if not self.initialized then
 		return
 	end
 
-	-- Player level changed.
-	if event == "PLAYER_LEVEL_UP" then
-		self:UpdateInfo(arg1)
-		BsItemInfo:InvalidateUsableCache()
+	-- Equipped gear changed ("inventory" in this case is what's equipped, not what's in bags).
+	-- [This used to also fire on UPDATE_INVENTORY_ALERTS, but that is about equipped gear *durability*.]
+	if event == "UPDATE_INVENTORY_ALERTS" then
+		-- This fires for all characters in a party/raid, and we only care about the player.
+		if  arg1 == "player" then
+			--self:UpdateGear()
+			Bagshui:QueueClassCallback(self, self.UpdateGear, 1)
+		end
 		return
 	end
 
-	-- Equipped gear changed ("inventory" in this case is what's equipped, not what's in bags).
+	-- Refresh spells/skills and remove any items from the profession tables that shouldn't be there anymore.
+	-- This is also where the initial update after PLAYER_ENTERING_WORLD occurs.
 	if
-		event == "UPDATE_INVENTORY_ALERTS"
-		or event == "UNIT_INVENTORY_CHANGED"
+				event == "SPELLS_CHANGED"
+				or event == "CHAT_MSG_SKILL"
+				or event == "SKILL_LINES_CHANGED"
 	then
-		self:UpdateGear()
+		Bagshui:QueueClassCallback(self, self.UpdateSkillsAndSpells, 1)
+		return
+	end
+
+	-- Player level changed.
+	if event == "PLAYER_LEVEL_UP" then
+		-- self:UpdateInfo(arg1)
+		Bagshui:QueueClassCallback(self, self.UpdateInfo, 1, false, arg1)
 		return
 	end
 
@@ -243,8 +237,7 @@ function Character:OnEvent(event, arg1)
 	-- This can only happen when the appropriate window is opened!
 	if event == "CRAFT_SHOW" or event == "TRADE_SKILL_SHOW" then
 		-- Wait a smidgen before attempting the update so that game functions will return values.
-		Bagshui:QueueClassCallback(self, self.UpdateProfessionItems, 0.75, false, event)
-		BsItemInfo:InvalidateUsableCache()
+		Bagshui:QueueClassCallback(self, self.UpdateProfessionItems, 1, false, event)
 		return
 	end
 
@@ -294,6 +287,7 @@ function Character:UpdateInfo(newLevel)
 		for key, value in pairs(self.info) do
 			if self.info[key] ~= _updateInfo_oldValues[key] then
 				Bagshui:RaiseEvent("BAGSHUI_CHARACTER_UPDATE")
+				BsItemInfo:InvalidateUsableCache()
 				break
 			end
 		end
@@ -367,6 +361,9 @@ function Character:UpdateSkillsAndSpells()
 		end
 	end
 
+	-- Cleanup.
+	self:PruneProfessionItems()
+
 	-- Is anything different?
 	if
 		self.initialized
@@ -376,6 +373,7 @@ function Character:UpdateSkillsAndSpells()
 		)
 	then
 		Bagshui:RaiseEvent("BAGSHUI_CHARACTER_UPDATE")
+		BsItemInfo:InvalidateUsableCache()
 	end
 
 	-- Don't need to keep contents (but do keep the tables).
@@ -461,6 +459,7 @@ function Character:PruneProfessionItems()
 		self:PruneItemList(self.professionReagents)
 	then
 		Bagshui:RaiseEvent("BAGSHUI_PROFESSION_ITEM_UPDATE")
+		BsItemInfo:InvalidateUsableCache()
 	end
 end
 
@@ -554,6 +553,7 @@ function Character:UpdateProfessionItems(event)
 	-- Notify of changes.
 	if changesMade then
 		Bagshui:RaiseEvent("BAGSHUI_PROFESSION_ITEM_UPDATE")
+		BsItemInfo:InvalidateUsableCache()
 	end
 end
 


### PR DESCRIPTION
## Description
Stop lag in raid groups by fixing over-eager character-related event consumption
- Check arg1 for UNIT_INVENTORY_CHANGED so we ignore it for party/raid members.
- Delay all character updates by 1 second to allow multiple events to coalesce.
- Remove UPDATE_INVENTORY_ALERTS -- this is about durability, not equipped gear changes.

## Motivation and context
#153


## Types of changes
- Bug fix <!--- Non-breaking change that resolves an issue -->