### PR TITLE
Add bold borders and 3rd party interface skin API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 # Bagshui Changelog
 
-## 1.5.10 - 2025-04-26
+## 1.6.0 - 2025-06-05
+### Changes
+* Add 3rd party interface skin API to support UI replacements like [Dragonflight: Reloaded](https://github.com/MtxGrower33/DragonflightReloaded).
+
+## 1.5.10 - 2025-05-19
 ### Fixed
 * Prevent lag while in a raid group. Additional protections for in-combat performance are being tested, but this should resolve the worst of the [issues](https://github.com/veechs/Bagshui/issues/153). Thanks to jj for their patient testing that helped me locate the root cause.
 

--- a/Components/API.lua
+++ b/Components/API.lua
@@ -94,4 +94,71 @@ function Bagshui:QueueInventoryUpdate(delay, resortNeeded, cacheUpdateNeeded, fu
 end
 
 
+
+--- Register and immediately activate a 3rd party interface skin.
+--- 
+--- ## ℹ️ About
+--- This API is designed for use by full UI replacements like Dragonflight: Reloaded
+--- to help Bagshui blend in. It *cannot* be used to provide additional optional
+--- appearances for Bagshui's item slots.
+--- 
+--- ### ⚠️ Limitations
+--- 
+---   - Bagshui does *not* currently provide the user a way to switch skins or
+---      deactivate them; it's up to the 3rd party addon to handle this.
+--- 
+---   - First interface skin registered wins, so if a user loads (for example) both
+---     pfUI and Dragonflight: Reloaded, the built-in pfUI interface skin will already
+---     be active when DF:RL tries to add its skin, an error will be printed to chat.
+--- 
+--- ### 📖 Sample code
+--- ```
+--- -- Bagshui Interface Skin API Example
+--- -- Simple demonstration of registering a 3rd party interface skin for Bagshui.
+--- 
+--- -- Explicit access to global environment for clarity.
+--- local _G = _G or getfenv()
+--- 
+--- -- Need a frame to process events.
+--- local SkinDemo = _G.CreateFrame("Frame")
+--- 
+--- --- Event handler.
+--- --- Vanilla event parameters come via global variables, not function parameters.
+--- SkinDemo:SetScript("OnEvent", function()
+--- 
+--- 	-- Interface skin registration *must* occur during ADDON_LOADED so it's done before
+--- 	-- Bagshui starts building the interface during PLAYER_LOGIN/PLAYER_ENTERING_WORLD.
+--- 	if _G.event == "ADDON_LOADED" then
+--- 		-- Only respond to the event for this addon.
+--- 		if _G.arg1 == "Bagshui-InterfaceSkin-Demo" then
+--- 			-- Make sure Bagshui is loaded and a new enough version to have the interface skin API.
+--- 			if _G.IsAddOnLoaded("Bagshui") and _G.Bagshui and _G.Bagshui.AddInterfaceSkin then
+--- 				Bagshui:AddInterfaceSkin(
+--- 					"Demo",
+--- 					{
+--- 						-- Garish, but readily apparent that it's working.
+--- 						-- This is just a demo, after all.
+--- 						inventoryBackgroundColorFromSkin = { 0.5, 0, 0.4 },
+--- 						inventoryBorderColorFromSkin = { 0, 0.3, 0.8 },
+--- 					}
+--- 				)
+--- 			end
+--- 		end
+--- 		return
+--- 	end
+--- 
+--- end)
+--- 
+--- -- Have WoW send us the required event.
+--- SkinDemo:RegisterEvent("ADDON_LOADED")
+--- ```
+--- 
+---@param skinName string Name of the skin. This may be visible to the user.
+---@param skinConfig table Skin details. See **Config\Skins.lua** for the expected format.
+function Bagshui:AddInterfaceSkin(skinName, skinConfig)
+	BsSkinMgr:AddInterfaceSkin(skinName, skinConfig)
+	BsSkinMgr:ActivateInterfaceSkin(skinName)
+end
+
+
 end)

--- a/Components/API.lua
+++ b/Components/API.lua
@@ -140,7 +140,7 @@ end
 --- 	-- Bagshui starts building the interface during PLAYER_LOGIN/PLAYER_ENTERING_WORLD.
 --- 	if _G.event == "ADDON_LOADED" then
 --- 		-- Only respond to the event for this addon.
---- 		if _G.arg1 == "Bagshui-InterfaceSkin-Demo" then
+--- 		if _G.arg1 == "YourAddonName" then
 --- 			-- Make sure Bagshui is loaded and a new enough version to have the interface skin API.
 --- 			if _G.IsAddOnLoaded("Bagshui") and _G.Bagshui and _G.Bagshui.AddInterfaceSkin then
 --- 				Bagshui:AddInterfaceSkin(

--- a/Components/API.lua
+++ b/Components/API.lua
@@ -102,6 +102,16 @@ end
 --- to help Bagshui blend in. It *cannot* be used to provide additional optional
 --- appearances for Bagshui's item slots.
 --- 
+--- ### 🧩 `skinConfig` values
+--- When calling `Bagshui:AddInterfaceSkin()`, the second parameter is a table containing
+--- all the information needed to apply your skin. Refer to **Config\Skins.lua** for documentation
+--- of available properties and expected values, along with an example implementation in the
+--- pfUI skin.
+--- 
+--- Note that any values you omit from your `skinConfig` will automatically be picked up from
+--- the default "Bagshui" skin. In other words, you *don't* need to provide properties unless
+--- they're different from the default.
+--- 
 --- ### ⚠️ Limitations
 --- 
 ---   - Bagshui does *not* currently provide the user a way to switch skins or

--- a/Components/Character.lua
+++ b/Components/Character.lua
@@ -156,7 +156,7 @@ Bagshui.components.Character = Character
 ---@param event string WoW API event
 ---@param arg1 any First event argument.
 function Character:OnEvent(event, arg1)
-	Bagshui:PrintDebug("Character event " .. event .. " // " .. tostring(arg1))
+	--Bagshui:PrintDebug("Character event " .. event .. " // " .. tostring(arg1))
 
 	-- Initial processing at startup. The delayed event is necessary to ensure
 	-- we can actually get the data we need, which isn't available instantly.

--- a/Components/Inventory.Layout.lua
+++ b/Components/Inventory.Layout.lua
@@ -487,14 +487,14 @@ function Inventory:UpdateWindow()
 	self.windowColor = self.settings.windowBackground
 	self.borderColor = self.settings.windowBorder
 
-	if self.settings.windowUseSkinColors and BsSkin.skinBackgroundColor then
-		self.windowColor = BsSkin.skinBackgroundColor
+	if self.settings.windowUseSkinColors and BsSkin.inventoryBackgroundColorFromSkin then
+		self.windowColor = BsSkin.inventoryBackgroundColorFromSkin
 	end
 
 	if not self.online then
 		self.borderColor = BS_COLOR.RED
-	elseif self.settings.windowUseSkinColors and BsSkin.skinBorderColor then
-		self.borderColor = BsSkin.skinBorderColor
+	elseif self.settings.windowUseSkinColors and BsSkin.inventoryBorderColorFromSkin then
+		self.borderColor = BsSkin.inventoryBorderColorFromSkin
 	end
 
 	self.uiFrame:SetBackdropColor(

--- a/Components/Inventory.Ui.Group.lua
+++ b/Components/Inventory.Ui.Group.lua
@@ -294,12 +294,12 @@ function InventoryUi:SetGroupColors(uiGroup, mouseDown)
 		-- 3. Default colors.
 
 		backdropColor = inventory.groups[groupId] and inventory.groups[groupId].background
-						or inventory.settings.groupUseSkinColors and BsSkin.skinBackgroundColor
+						or inventory.settings.groupUseSkinColors and BsSkin.inventoryBackgroundColorFromSkin
 		                or inventory.settings.groupBackgroundDefault
 		backdropOpacity = backdropColor[4]
 
 		borderColor = inventory.groups[groupId] and inventory.groups[groupId].border
-					  or inventory.settings.groupUseSkinColors and BsSkin.skinBorderColor
+					  or inventory.settings.groupUseSkinColors and BsSkin.inventoryBorderColorFromSkin
 		              or inventory.settings.groupBorderDefault
 		borderOpacity = borderColor[4]
 

--- a/Components/Skins.lua
+++ b/Components/Skins.lua
@@ -1,23 +1,110 @@
 -- Bagshui UI Skinning settings processing.
--- Exposes: BsSkin (and Bagshui.components.Skin)
+-- Exposes:
+-- - BsSkin (and Bagshui.components.Skin) - The currently active skin.
+-- - BsSkinMgr (and Bagshui.components.SkinManager) - Class for registering/activating skins.
 --
--- The active skin is decided in Config\Skins.lua. All we're doing here is:
--- 1. Pointing the BsSkin Bagshui environment variable to the active skin.
--- 2. If the active skin isn't the default, applying a metatable so that anything
+-- The default active skin is decided in Config\Skins.lua. When this component is loaded:
+-- 1. The BsSkin Bagshui environment variable is pointed to the active skin.
+-- 2. If the active skin isn't the default, a metatable is applied so that anything
 --    missing from the active skin will be picked up from the default.
 
 Bagshui:LoadComponent(function()
 
-Bagshui.environment.BsSkin = Bagshui.config.Skins.Bagshui
+-- Bagshui.environment.BsSkin = Bagshui.config.Skins.Bagshui
 
--- Active skin is not the default.
-if Bagshui.config.Skins.activeSkin ~= "Bagshui" and Bagshui.config.Skins[Bagshui.config.Skins.activeSkin] then
-	Bagshui.environment.BsSkin = Bagshui.config.Skins[Bagshui.config.Skins.activeSkin]
-	setmetatable(Bagshui.environment.BsSkin, Bagshui.config.Skins.Bagshui)
-	Bagshui.config.Skins.Bagshui.__index = Bagshui.config.Skins.Bagshui
+-- -- Active skin is not the default.
+-- if Bagshui.config.Skins.activeSkin ~= "Bagshui" and Bagshui.config.Skins[Bagshui.config.Skins.activeSkin] then
+-- 	Bagshui.environment.BsSkin = Bagshui.config.Skins[Bagshui.config.Skins.activeSkin]
+-- 	setmetatable(Bagshui.environment.BsSkin, Bagshui.config.Skins.Bagshui)
+-- 	Bagshui.config.Skins.Bagshui.__index = Bagshui.config.Skins.Bagshui
+-- end
+
+-- Bagshui.components.Skin = Bagshui.environment.BsSkin
+
+
+local SkinMgr = {
+	activeSkin = "Bagshui",
+	skins = {},
+}
+Bagshui.components.SkinManager = SkinMgr
+Bagshui.environment.BsSkinMgr = SkinMgr
+
+
+
+--- Initialize the SkinManager class.
+function SkinMgr:Init()
+	-- Load built-in skins.
+	for skinName, skinConfig in pairs(Bagshui.config.Skins) do
+		if skinName ~= "_activeSkin" then
+			self:AddInterfaceSkin(skinName, skinConfig)
+		end
+	end
+
+	-- Set default active skin.
+	self:ActivateInterfaceSkin(Bagshui.config.Skins._activeSkin)
 end
 
-Bagshui.components.Skin = Bagshui.environment.BsSkin
+
+
+--- Register a new interface skin.
+--- Designed to help Bagshui blend in with full UI replacement addons.
+--- (This function is named as such in case Inventory-only skins are added in the future.)
+--- 
+--- 🛑 3rd party addons should not call this directly -- use the Bagshui:AddInterfaceSkin() API instead. 🛑
+--- 
+---@param skinName string Name of the skin. This may be visible to the user.
+---@param skinConfig table Skin details. See **Config\Skins.lua** for the expected format.
+function SkinMgr:AddInterfaceSkin(skinName, skinConfig)
+	assert(type(skinName) == "string", "SkinMgr:AddInterfaceSkin(): skinName must be a string")
+	assert(type(skinConfig) == "table", "SkinMgr:AddInterfaceSkin(): skinConfig must be a table")
+	-- Not much to do here other than toss the skin in the list of known skins.
+	self.skins[skinName] = skinConfig
+end
+
+
+
+--- Change the active skin.
+--- ⚠️ As of now, this should **only** be called at startup, since it will *not*
+---    apply changes to UI elements that have already been created. ⚠️
+---@param skinName any
+function SkinMgr:ActivateInterfaceSkin(skinName)
+	assert(type(skinName) == "string", "SkinMgr:ActivateInterfaceSkin(): skinName must be a string")
+	assert(self.skins[skinName], "SkinMgr:ActivateInterfaceSkin(): " .. tostring(skinName) .. " is not a registered Bagshui interface skin")
+
+	-- Don't let multiple interface skins fight each other.
+	if self.activeSkin ~= "Bagshui" then
+		Bagshui:PrintWarning(
+			"An attempt was made to activate the " .. skinName .. " skin, but the " .. self.activeSkin .. " is already active. "
+			.. "Only one interface skin can be active at a time, and the first one activated wins."
+		)
+		return
+	end
+
+	-- Activate the skin.
+	self.activeSkin = skinName
+	Bagshui.environment.BsSkin = self.skins[skinName]
+	Bagshui.components.Skin = Bagshui.environment.BsSkin
+
+	-- When the active skin isn't the default one, set a metatable to transparently
+	-- handle any missing values.
+	if skinName ~= "Bagshui" and self.skins[skinName] then
+		setmetatable(Bagshui.environment.BsSkin, self.skins.Bagshui)
+		self.skins.Bagshui.__index = self.skins.Bagshui
+	end
+end
+
+
+
+--- Obtain the name of the active skin.
+---@return string activeSkin
+function SkinMgr:GetActiveSkinName()
+	return self.activeSkin
+end
+
+
+
+-- Initialize immediately.
+SkinMgr:Init()
 
 
 end)

--- a/Components/Skins.lua
+++ b/Components/Skins.lua
@@ -66,6 +66,9 @@ end
 --- Change the active skin.
 --- ⚠️ As of now, this should **only** be called at startup, since it will *not*
 ---    apply changes to UI elements that have already been created. ⚠️
+--- 
+--- 🛑 3rd party addons should not call this directly -- use the Bagshui:AddInterfaceSkin() API instead. 🛑
+--- 
 ---@param skinName any
 function SkinMgr:ActivateInterfaceSkin(skinName)
 	assert(type(skinName) == "string", "SkinMgr:ActivateInterfaceSkin(): skinName must be a string")

--- a/Components/Ui.ItemButton.lua
+++ b/Components/Ui.ItemButton.lua
@@ -234,7 +234,7 @@ end
 
 --- Apply all our visual customizations to an item slot (or bag slot) button.
 ---@param button table Button to skin.
-function Ui:SkinItemButton(button, buttonType)
+function Ui:SkinItemButton(button)
 	if not button.bagshuiData then
 		button.bagshuiData = {}
 	end
@@ -245,7 +245,7 @@ function Ui:SkinItemButton(button, buttonType)
 	buttonInfo.originalSizeAdjusted = button.bagshuiData.originalSize + (BsSkin.itemSlotSizeFudge or 0)
 
 	-- Treat as an item slot button unless the button has been configured as something else.
-	buttonType = buttonInfo.type or BS_UI_ITEM_BUTTON_TYPE.ITEM
+	local buttonType = buttonInfo.type or BS_UI_ITEM_BUTTON_TYPE.ITEM
 
 	local buttonName = button:GetName()
 

--- a/Components/Ui.ItemButton.lua
+++ b/Components/Ui.ItemButton.lua
@@ -342,10 +342,10 @@ function Ui:SkinItemButton(button)
 	if BsSkin.itemSlotBoldBorderSupported then
 		buttonComponents.borderBold:SetTexture(BsUtil.GetFullTexturePath(BsSkin.itemSlotBoldBorderTexture))
 		buttonComponents.borderBold:SetTexCoord(
-			BsSkin.itemSlotBorderTexCoord[1],
-			BsSkin.itemSlotBorderTexCoord[2],
-			BsSkin.itemSlotBorderTexCoord[3],
-			BsSkin.itemSlotBorderTexCoord[4]
+			BsSkin.itemSlotBoldBorderTexCoord[1],
+			BsSkin.itemSlotBoldBorderTexCoord[2],
+			BsSkin.itemSlotBoldBorderTexCoord[3],
+			BsSkin.itemSlotBoldBorderTexCoord[4]
 		)
 	end
 	buttonComponents.borderBold:SetVertexColor(1, 1, 1, 0)

--- a/Components/Ui.ItemButton.lua
+++ b/Components/Ui.ItemButton.lua
@@ -329,11 +329,27 @@ function Ui:SkinItemButton(button)
 	buttonComponents.border:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", BsSkin.itemSlotBorderAnchor, -BsSkin.itemSlotBorderAnchor)
 	buttonInfo.borderBackdropTable = {
 		tile = false, tileSize = 0,
-		edgeFile = BsSkin.itemSlotBorderTexture,
+		edgeFile = BsUtil.GetFullTexturePath(BsSkin.itemSlotBorderTexture),
 		edgeSize = BsSkin.itemSlotEdgeSize,
 		insets = { left = BsSkin.itemSlotInset, right = BsSkin.itemSlotInset, top = BsSkin.itemSlotInset, bottom = BsSkin.itemSlotInset }
 	}
 	buttonComponents.border:SetBackdrop(buttonInfo.borderBackdropTable)
+
+	-- Inspired by [BetterBags "Extra Glowy Buttons"](https://github.com/Cidan/BetterBags/blob/main/frames/item.lua).
+	buttonComponents.borderBold = buttonComponents.border:CreateTexture(nil, "BORDER")
+	buttonComponents.borderBold:SetAllPoints(buttonComponents.border)
+	buttonComponents.borderBold:SetBlendMode("ADD")
+	if BsSkin.itemSlotBoldBorderSupported then
+		buttonComponents.borderBold:SetTexture(BsUtil.GetFullTexturePath(BsSkin.itemSlotBoldBorderTexture))
+		buttonComponents.borderBold:SetTexCoord(
+			BsSkin.itemSlotBorderTexCoord[1],
+			BsSkin.itemSlotBorderTexCoord[2],
+			BsSkin.itemSlotBorderTexCoord[3],
+			BsSkin.itemSlotBorderTexCoord[4]
+		)
+	end
+	buttonComponents.borderBold:SetVertexColor(1, 1, 1, 0)
+
 	buttonInfo.forceBorderDisplay = BsSkin.itemSlotBorderAlwaysShow
 	buttonInfo.qualityColor = BsSkin.itemSlotBorderDefaultColor
 
@@ -769,6 +785,8 @@ function Ui:UpdateItemButtonColorsAndBadges(button, force)
 	else
 		-- Normal processing (non-Inventory item slot buttons or Inventory and not Edit Mode).
 
+		local boldBorders = BsSkin.itemSlotBoldBorderSupported and inventory and inventory.settings.itemBordersBold or false
+
 		-- Dim non-matching items on container highlight.
 		if
 			inventory
@@ -836,11 +854,13 @@ function Ui:UpdateItemButtonColorsAndBadges(button, force)
 			buttonInfo.qualityColor.r,
 			buttonInfo.qualityColor.g,
 			buttonInfo.qualityColor.b,
-			(
-				((inventory or buttonInfo.colorBorders) and item and item.quality > -1 and item.locked ~= 1) and (opacityOverride or BsSkin.itemSlotBorderOpacity)
-				or (buttonInfo.forceBorderDisplay and opacityOverride or buttonInfo.qualityColor.a)
-				or 0
-			)
+			self:GetItemButtonBorderOpacity(true, 0, (boldBorders and 1 or nil), opacityOverride, inventory, buttonInfo, item)
+		)
+		buttonComponents.borderBold:SetVertexColor(
+			buttonInfo.qualityColor.r,
+			buttonInfo.qualityColor.g,
+			buttonInfo.qualityColor.b,
+			self:GetItemButtonBorderOpacity(false, (boldBorders and 2 or 999), nil, opacityOverride, inventory, buttonInfo, item)
 		)
 
 		-- Only color inner glow for Uncommon and up.
@@ -889,6 +909,12 @@ function Ui:UpdateItemButtonColorsAndBadges(button, force)
 				BS_COLOR.ITEM_SLOT_HIGHLIGHT[2],
 				BS_COLOR.ITEM_SLOT_HIGHLIGHT[3],
 				BsSkin.itemSlotBorderContainerHighlightOpacity
+			)
+			buttonComponents.borderBold:SetVertexColor(
+				BS_COLOR.ITEM_SLOT_HIGHLIGHT[1],
+				BS_COLOR.ITEM_SLOT_HIGHLIGHT[2],
+				BS_COLOR.ITEM_SLOT_HIGHLIGHT[3],
+				boldBorders and BsSkin.itemSlotBorderContainerHighlightOpacity or 0
 			)
 			if buttonComponents.innerGlow then
 				buttonComponents.innerGlow:SetVertexColor(
@@ -1038,6 +1064,43 @@ function Ui:UpdateItemButtonStockState(button)
 		end
 	end
 
+end
+
+
+
+--- Decide whether an item border should be visible based on the provided criteria.
+---@param isDefaultBorder boolean Is this for the primary item slot border or the bold one?
+---@param qualityMin number? If an item is provided, its quality must be of this level or higher for the border to show.
+---@param qualityMax number? If an item is provided, its quality must be of this level or lower for the border to show.
+---@param opacityOverride number? Alpha override from UpdateItemButtonColorsAndBadges().
+---@param inventory table? Bagshui Inventory class that owns the item button, if any.
+---@param buttonInfo table `bagshuiData` property from the item button.
+---@param item table? Item assigned to the button, if any.
+---@return number opacity
+function Ui:GetItemButtonBorderOpacity(isDefaultBorder, qualityMin, qualityMax, opacityOverride, inventory, buttonInfo, item)
+	qualityMin = qualityMin or -1
+	qualityMax = qualityMax or 999
+	return
+		(
+			(
+				inventory
+				or buttonInfo.colorBorders
+			)
+			and item
+			and item.quality >= qualityMin
+			and item.quality <= qualityMax
+			and item.locked ~= 1
+		)
+		and (opacityOverride or BsSkin.itemSlotBorderOpacity)
+
+		or isDefaultBorder
+		and (
+			buttonInfo.forceBorderDisplay
+			and opacityOverride
+			or buttonInfo.qualityColor.a
+		)
+
+		or 0
 end
 
 

--- a/Config/Settings.lua
+++ b/Config/Settings.lua
@@ -1086,6 +1086,32 @@ Bagshui.config.Settings = {
 				},
 
 				{
+					menuTitle = L.Menu_Settings_ItemSlots,
+				},
+				{
+					name = "itemBordersBold",
+					scope = BS_SETTING_SCOPE.INVENTORY,
+					profileScope = BS_SETTING_PROFILE_SCOPE.DESIGN,
+					type = BS_SETTING_TYPE.BOOLEAN,
+					textDisplayFunc = function(name, settingName, settings)
+						return name .. ((not BsSkin.itemSlotBoldBorderSupported) and (LIGHTYELLOW_FONT_COLOR_CODE .. " ×" .. FONT_COLOR_CODE_CLOSE) or "")
+					end,
+					tooltipTextDisplayFunc = function(tooltipText, settingName, settings)
+						return string.gsub(
+							tooltipText,
+							"~1~",
+							(
+								(not BsSkin.itemSlotBoldBorderSupported)
+								and (LIGHTYELLOW_FONT_COLOR_CODE .. L.Setting_DisabledBy_Skin .. FONT_COLOR_CODE_CLOSE .. BS_NEWLINE)
+								or ""
+							)
+						)
+					end,
+					defaultValue = false,
+					inventoryWindowUpdateOnChange = true,
+				},
+
+				{
 					menuTitle = L.Menu_Settings_Tinting,
 				},
 				{

--- a/Config/Settings.lua
+++ b/Config/Settings.lua
@@ -1019,7 +1019,7 @@ Bagshui.config.Settings = {
 
 
 				{
-					menuTitle = L.Menu_Settings_Buttons
+					menuTitle = L.Menu_Settings_ToolbarButtons
 				},
 
 				{

--- a/Config/Settings.lua
+++ b/Config/Settings.lua
@@ -84,7 +84,7 @@ end
 --- their menu entries when the default skin is active.
 ---@return boolean
 local function useSkinColorsHide()
-	return Bagshui.config.Skins.activeSkin == "Bagshui"
+	return BsSkinMgr:GetActiveSkinName() == "Bagshui"
 end
 
 
@@ -93,7 +93,7 @@ end
 ---@param nameString string
 ---@return string updatedNameString
 local function useSkinColorsName(nameString)
-	return string.format(nameString, Bagshui.config.Skins.activeSkin)
+	return string.format(nameString, BsSkinMgr:GetActiveSkinName())
 end
 
 
@@ -126,7 +126,7 @@ end
 ---@return boolean
 local function disableWhenUsingSkinColors(settingName, settings)
 	return
-		Bagshui.config.Skins.activeSkin ~= "Bagshui"
+		BsSkinMgr:GetActiveSkinName() ~= "Bagshui"
 		and settings[(string.find(settingName, "^group") and "group" or "window") .. "UseSkinColors"]
 end
 

--- a/Config/Skins.lua
+++ b/Config/Skins.lua
@@ -152,6 +152,19 @@ Bagshui.config.Skins = {
 		---@type number Item slot inner opacity for container mouseover highlight.
 		itemSlotBorderContainerHighlightOpacity = 1,
 
+		---@type boolean Enable bold item borders.
+		itemSlotBoldBorderSupported = true,
+		---@type string Texture to use for bold item borders.
+		-- Some extra explanation is probably needed here, because standard and bold borders
+		-- are handled differently.
+		-- - Standard borders are "true" borders added via SetBackdrop() using an edgeFile texture.
+		-- - Bold borders are a square texture positioned using SetTexCoord().
+		-- Why? Because it was easiest to do things this way with the resources available
+		-- in Vanilla to avoid shipping extra textures.
+		itemSlotBoldBorderTexture = "Interface\\Buttons\\UI-ActionButton-Border",
+		---@type table { left, right, top, bottom }: Item slot border SetTexCoord parameters.
+		itemSlotBorderTexCoord = { 12/64, 51/64, 13/64, 52/64 },
+
 		---@type string Replacement texture for item slot HighlightTexture.
 		itemSlotHighlightTexture = nil,
 		---@type number Item slot HighlightTexture anchor (positive = outset / negative = inset).
@@ -443,6 +456,9 @@ if (pfUI and pfUI.api and pfUI.env and pfUI.env.C) then
 				itemSlotBorderInverseScale = true,
 				itemSlotBorderAlwaysShow = true,
 				itemSlotBorderDefaultColor = { r = 0.4, g = 0.4, b = 0.4, a = 0.5 },
+
+				-- The concept of bold borders doesn't make sense in the flat style.
+				itemSlotBoldBorderSupported = false,
 
 				itemSlotHighlightTexture = "ItemSlot\\Flat-Highlight",
 				itemSlotHighlightAnchor = 2,

--- a/Config/Skins.lua
+++ b/Config/Skins.lua
@@ -6,21 +6,17 @@ Bagshui:LoadComponent(function()
 local Ui = Bagshui.prototypes.Ui
 
 Bagshui.config.Skins = {
-	activeSkin = "Bagshui",
+	-- This property will be picked up during SkinManager initialization and used to determine the active interface skin.
+	_activeSkin = "Bagshui",
 
+	-- Default skin.
 	Bagshui = {
 
+		-- Window frame colors. Used for all non-inventory Bagshui windows.
 		---@type table { number: r, number: g, number: b, number: a }: Window frame background color.
 		frameBackgroundColor = { 0.1, 0.1, 0.1, 0.99 },
 		---@type table { number: r, number: g, number: b, number: a }: Window frame border color.
 		frameBorderColor = nil,
-
-		-- When these have values, an additional item will appear in settings menus for colors
-		-- to allow the selection of the skin's default colors.
-		---@type table { number: r, number: g, number: b, number: a }
-		skinBackgroundColor = nil,
-		---@type table { number: r, number: g, number: b, number: a }
-		skinBorderColor = nil,
 
 		---@type string Frame default backdrop texture.
 		frameDefaultBackdrop = "Interface\\BUTTONS\\WHITE8X8",
@@ -97,7 +93,14 @@ Bagshui.config.Skins = {
 		---@type number Close button X coordinate shift for inventory windows only.
 		closeButtonInventoryWindowXOffsetAdjustment = 0,
 
-		---@type number Minimum inventory window width.
+		-- When these have values, an additional item will appear in inventory settings menus for colors
+		-- to allow the use of the skin's colors in lieu of any custom colors.
+		---@type table { number: r, number: g, number: b, number: a }
+		inventoryBackgroundColorFromSkin = nil,
+		---@type table { number: r, number: g, number: b, number: a }
+		inventoryBorderColorFromSkin = nil,
+
+		---@type number Minimum inventory window width. (⚠️ 3rd party skins probably shouldn't override this unless there's a *really* good reason.)
 		inventoryWindowMinWidth = 400,
 		---@type number Inventory window padding.
 		inventoryWindowPadding = 6,
@@ -272,8 +275,8 @@ if (pfUI and pfUI.api and pfUI.env and pfUI.env.C) then
 			frameBackgroundColor = { pfUI.api.GetStringColor(pfUI.env.C.appearance.border.background) },
 			frameBorderColor = { pfUI.api.GetStringColor(pfUI.env.C.appearance.border.color) },
 
-			skinBackgroundColor = { pfUI.api.GetStringColor(pfUI.env.C.appearance.border.background) },
-			skinBorderColor = { pfUI.api.GetStringColor(pfUI.env.C.appearance.border.color) },
+			inventoryBackgroundColorFromSkin = { pfUI.api.GetStringColor(pfUI.env.C.appearance.border.background) },
+			inventoryBorderColorFromSkin = { pfUI.api.GetStringColor(pfUI.env.C.appearance.border.color) },
 
 			frameDefaultBorderStyle = {
 				edgeFile = pfUI.backdrop_blizz_border.edgeFile,
@@ -491,7 +494,7 @@ if (pfUI and pfUI.api and pfUI.env and pfUI.env.C) then
 		end
 
 		Bagshui.config.Skins.pfUI = pfUISkin
-		Bagshui.config.Skins.activeSkin = "pfUI"
+		Bagshui.config.Skins._activeSkin = "pfUI"
 	end
 end
 

--- a/Config/Skins.lua
+++ b/Config/Skins.lua
@@ -163,7 +163,7 @@ Bagshui.config.Skins = {
 		-- in Vanilla to avoid shipping extra textures.
 		itemSlotBoldBorderTexture = "Interface\\Buttons\\UI-ActionButton-Border",
 		---@type table { left, right, top, bottom }: Item slot border SetTexCoord parameters.
-		itemSlotBorderTexCoord = { 12/64, 51/64, 13/64, 52/64 },
+		itemSlotBoldBorderTexCoord = { 12/64, 51/64, 13/64, 52/64 },
 
 		---@type string Replacement texture for item slot HighlightTexture.
 		itemSlotHighlightTexture = nil,

--- a/Credits.md
+++ b/Credits.md
@@ -23,7 +23,7 @@ Bagshui started life as a rewrite of EngBags and therefore would not exist witho
 
 ### Reuse
 * Active quest item detection based on [QuestItem](https://github.com/wow-vanilla-addons/QuestItem) by Shagoth.
-* Item borders use code from [ShaguTweaks](https://github.com/shagu/ShaguTweaks) `AddBorder()` by Shagu and [ShaguTweaks-Mods](https://github.com/GryllsAddons/ShaguTweaks-mods) `AddTexture()` by Grylls.
+* Item borders use code from [ShaguTweaks](https://github.com/shagu/ShaguTweaks) `AddBorder()` by Shagu and [ShaguTweaks-Mods](https://github.com/GryllsAddons/ShaguTweaks-mods) `AddTexture()` by Grylls, with inspiration from [BetterBags](https://github.com/Cidan/BetterBags) by Cidan.
 * Unusable item dyeing based on logic from [pfUI](https://github.com/shagu/pfUI) by shagu.
 * Icon button cooldown completion shine based on code from [OmniCC](https://github.com/anzz1/OmniCC) by Tuller & kebabstorm (which in turn adapted it from ABInfo by Ombres)
 * Import/export based on code from [pfUI](https://github.com/shagu/pfUI/) (modules/share.lua) by Shagu.

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -383,6 +383,7 @@ BsLocalization:AddLocale("enUS", {
 ["Menu_Settings_Tinting"] = "Item Tinting",
 ["Menu_Settings_Toggles"] = "Toggles",
 ["Menu_Settings_Toolbar"] = "Toolbar",
+["Menu_Settings_ToolbarButtons"] = "Toolbar Buttons",
 ["Menu_Settings_Tooltips"] = "Tooltips",
 ["Menu_Settings_ToggleBagsWith"] = "Toggle Bags With",
 ["Menu_Settings_StockBadgeColors"] = "Stock Colors",
@@ -1040,6 +1041,7 @@ BsLocalization:AddLocale("enUS", {
 ["SettingScope_Account"] = "Applies to all characters on this account.",
 ["SettingScope_Character"] = "Applies to all of this character's inventory windows.",
 ["Setting_DisabledBy_HideGroupLabels"] = "× Disabled because the active Structure has Hide Group Labels enabled.",
+["Setting_DisabledBy_Skin"] = "× Disabled because the current interface skin does not support this feature.",
 ["Setting_EnabledBy_ColorblindMode"] = "√ Enabled because Colorblind Mode is on.",
 ["Setting_Profile_SetAllHint"] = "Shift+Click to use for all profile types.",
 ["Setting_Reset_TooltipText"] = "Reset to default: Ctrl+Alt+Shift+Click.",
@@ -1153,6 +1155,10 @@ BsLocalization:AddLocale("enUS", {
 ["itemActiveQuestBadges"] = "Active Quest",
 ["itemActiveQuestBadges_TooltipTitle"] = "Item Slot Active Quest Badges",
 ["itemActiveQuestBadges_TooltipText"] = "Show a ? in the top when the item is an objective of an active quest.",
+
+["itemBordersBold"] = "Bold Borders",
+["itemBordersBold_TooltipTitle"] = "Bold Item Quality Borders",
+["itemBordersBold_TooltipText"] = "Add an extra glow to items of Uncommon quality and higher.",
 
 ["itemQualityBadges"] = "!!Quality!!",
 ["itemQualityBadges_TooltipTitle"] = "Item Quality Badges",


### PR DESCRIPTION
## Description
Bold Borders provide additional emphasis for item quality outlines (Settings > Design > View > Item Slots > Bold Borders).

The skin API is for other addon developers to use; see `Bagshui:AddInterfaceSkin()` function comments in Components\API.lua for details. This also includes some refactoring to enable 3rd party addons to register an interface skin during `ADDON_LOADED`, before Bagshui starts building interface elements, and built-in pfUI skin has been migrated to the new API.

## Motivation and context
Bold Borders: #59

The skin API is designed for use by full UI replacements like Dragonflight: Reloaded to help Bagshui blend in. It *cannot* be used to provide additional optional appearances for Bagshui's item slots.

## Testing
Turned Bold Borders setting on and off.

Verified that Bagshui loads correctly in the following scenarios:
* Standard Blizzard skin
* pfUI skin
* Test 3rd party skin

## Screenshots
#### Bold Borders
<img width="1318" height="800" alt="BoldBorders" src="https://github.com/user-attachments/assets/c11723fa-c2b8-4836-b924-f8d9074ad1b4" />

<br>*The test 3rd party skin isn't worth taking a screenshot of because all it does is change the colors.*

## Types of changes
- New feature <!--- Non-breaking change that adds functionality -->
- Refactoring <!--- No functional changes -->