### PR TITLE
Bagshui 1.5.15

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Bagshui Changelog
 
+## 1.5.15 - 2025-08-23
+### Fixed
+* *Actually* fix [empty slot backgrounds in non-enUS clients that don't have a Bagshui localization](https://github.com/veechs/Bagshui/issues/175) (was working in 1.5.13, but only due to the bug that was resolved in 1.5.14). <sup><small>🪲&nbsp;[@Trust-WoW](https://github.com/Trust-WoW)</small></sup>
+* *Actually* move Turtle WoW's **Verdant Rune** [to the Teleports Category](https://github.com/veechs/Bagshui/issues/179). <sup><small>🗃️&nbsp;[@xeropresence](https://github.com/xeropresence)</small></sup>
+
 ## 1.5.14 - 2025-08-23
 ### Fixed
 * Remove stray double negative in localization checks introduced by the #175 fix.
@@ -8,7 +13,7 @@
 ### Fixed
 * Empty slot backgrounds in non-enUS clients that don't have a Bagshui localization [shouldn't go on vacation anymore](https://github.com/veechs/Bagshui/issues/175). <sup><small>🪲&nbsp;[@Trust-WoW](https://github.com/Trust-WoW)</small></sup>
 * Prevent [an error](https://github.com/veechs/Bagshui/issues/177) during the bank slot purchase flow. <sup><small>🪲&nbsp;[@Arcitec](https://github.com/Arcitec)</small></sup>
-* Potential fix for [missing toolbars](https://github.com/veechs/Bagshui/issues/172). <sup><small>🪲&nbsp;[@Sleepybear](https://github.com/Sleepybear)</small></sup>
+* Fix for [rare occurrence of missing toolbars](https://github.com/veechs/Bagshui/issues/172). <sup><small>🪲&nbsp;[@Sleepybear](https://github.com/Sleepybear)</small></sup>
 * Turtle WoW's **Verdant Rune** is now [correctly placed in the Teleports Category](https://github.com/veechs/Bagshui/issues/179). <sup><small>🗃️&nbsp;[@xeropresence](https://github.com/xeropresence)</small></sup>
 
 ## 1.5.12 - 2025-08-20

--- a/Components/Localization.lua
+++ b/Components/Localization.lua
@@ -30,6 +30,10 @@ local Localization = {
 
 	-- List of available locales in the form of `{ <locale> = { <localization table> } }`.
 	locales = {},
+
+	-- Used by `Localization:AutoLocalize()` to keep track of what has already been automatically localized
+	-- so we don't double-localize (see that function for further explanation).
+	autoLocalized = {},
 }
 Bagshui.environment.BsLocalization = Localization
 Bagshui.components.Localization = Localization

--- a/Config/Categories.lua
+++ b/Config/Categories.lua
@@ -396,7 +396,7 @@ Bagshui.config.Categories = {
 		{
 			id = "Teleports",
 			name = L.Teleports,
-			sequence = 87,  -- Must run before Soulbound because some of these are soulbound.
+			sequence = 74,  -- Must run before Quest Items (and Soulbound).
 			list = {
 				6948,  -- Hearthstone
 				18986,  -- Ultrasafe Transporter: Gadgetzan


### PR DESCRIPTION
## Description
* Change the order in which automatic localization occurs. Item slots need to be handled before item classes and subclasses, because Bag **items** and bag **slots** are different in some languages, and Bagshui expects `L["Bag"]` to refer to **items**. (For example, in German, Bag items are Behälter, but bag slots are Tasche.)
* Evaluate the Teleports category before Quest Items.

## Motivation and context
Actual fixes for #175 and #179.

## Types of changes
- Bug fix
- Item categorization